### PR TITLE
#413 컨테스트 제출에 대해서는 Rank API 비활성화

### DIFF
--- a/backend/submission/views/oj.py
+++ b/backend/submission/views/oj.py
@@ -243,6 +243,9 @@ class SubmissionRankAPI(APIView):
         except Submission.DoesNotExist:
             return self.error("Submission does not exist")
 
+        if submission.contest is not None:
+            return self.error("This API is not available for contest submissions")
+
         if request.user.id != submission.user_id and not request.user.is_admin_role():
             return self.error("No permission for this submission")
 


### PR DESCRIPTION
# Changelog
- 컨테스트에서 랭킹이 악의적으로 사용되는 것을 방지하기 위해 `SubmissionRankAPI`를 컨테스트 문제에 대해서는 조회 불가능하도록 설정하였습니다.

# Testing
- 유닛테스트 통과
<img width="765" height="924" alt="image" src="https://github.com/user-attachments/assets/492251e6-ce1c-4ae4-9347-7346a4349ea7" />

# Ops Impact
N/A

# Version Compatibility
N/A