### PR TITLE
#440 커뮤니티 미해결 질문 모음 컴포넌트 구현

### DIFF
--- a/backend/community/views/oj.py
+++ b/backend/community/views/oj.py
@@ -70,6 +70,7 @@ class PostAPIView(APIView):
         contest_id = request.GET.get("contest_id")
         problem_id = request.GET.get("problem_id")
         post_type = request.GET.get("post_type")
+        question_status = request.GET.get("question_status")
 
         posts = Post.objects.select_related("author__userprofile").annotate(
             comment_count=Count('comments')).all().order_by("-created_at")
@@ -90,6 +91,9 @@ class PostAPIView(APIView):
 
         if post_type:
             posts = posts.filter(post_type=post_type)
+
+        if question_status:
+            posts = posts.filter(question_status=question_status)
 
         data = self.paginate_data(request, posts, PostListSerializer)
         return self.success(data)
@@ -136,12 +140,12 @@ class PostDetailAPIView(APIView):
             return self.error("No permission to edit this post")
 
         data = request.data
-        
+
         # ANNOUNCEMENT 타입으로 변경하려는 경우 Super Admin 권한 체크
         if "post_type" in data and data["post_type"] == Post.PostType.ANNOUNCEMENT:
             if not request.user.is_super_admin():
                 return self.error("Only Super Admin can set post type to announcement")
-        
+
         for key, value in data.items():
             setattr(post, key, value)
         post.save()

--- a/frontend/src/i18n/oj/en-US.js
+++ b/frontend/src/i18n/oj/en-US.js
@@ -563,4 +563,11 @@ export const m = {
   Community_Comment_Delete_Confirm: "댓글을 삭제하시겠습니까?",
   Community_Comment_Delete_Success: "댓글이 삭제되었습니다.",
   Community_Comment_Delete_Failed: "댓글 삭제에 실패했습니다.",
+
+  // QuestionList.vue
+  Community_Question_Title: "친구들의 질문",
+  Community_Question_Subtitle: "답변으로 도움을 주세요!",
+  Community_Question_No_Questions: "현재는 등록된 질문이 없어요.",
+  Community_Question_Open: "미해결",
+  Community_Question_Closed: "해결됨",
 }

--- a/frontend/src/pages/oj/api.js
+++ b/frontend/src/pages/oj/api.js
@@ -385,11 +385,19 @@ export default {
     return ajax("banner", "get")
   },
 
-  getCommunityPostList(offset, limit) {
+  getCommunityPostList(
+    offset,
+    limit,
+    post_type = null,
+    question_status = null,
+  ) {
     const params = {
       offset,
       limit,
     }
+
+    if (post_type) params.post_type = post_type
+    if (question_status) params.question_status = question_status
 
     return ajax("community/posts", "get", {
       params,

--- a/frontend/src/pages/oj/views/community/Community.vue
+++ b/frontend/src/pages/oj/views/community/Community.vue
@@ -70,6 +70,7 @@
         </div>
         <div class="right-container">
           <CreatePost />
+          <QuestionList />
         </div>
       </div>
     </div>
@@ -82,11 +83,13 @@ import Pagination from "@/pages/admin/components/Pagination.vue"
 import ErrorSign from "../general/ErrorSign.vue"
 import CreatePost from "./communityComponent/CreatePost.vue";
 import { POST_TYPE, QUESTION_STATUS } from "../../../../utils/constants";
+import QuestionList from "./communityComponent/QuestionList.vue";
 
 export default {
   name: "Community",
   components: {
     CreatePost,
+    QuestionList,
     Pagination,
     ErrorSign,
   },

--- a/frontend/src/pages/oj/views/community/communityComponent/QuestionList.vue
+++ b/frontend/src/pages/oj/views/community/communityComponent/QuestionList.vue
@@ -1,0 +1,243 @@
+<template>
+  <div class="question-list-widget">
+    <div class="widget-header">
+      <h3 class="widget-title">
+        <Icon type="ios-help-circle" size="20"></Icon>
+        {{ $t("m.Community_Question_Title") }}
+      </h3>
+      <p class="widget-subtitle">{{ $t("m.Community_Question_Subtitle") }}</p>
+    </div>
+
+    <div class="question-items">
+      <div v-for="question in questions" :key="question.id" class="question-item" @click="goToQuestion(question.id)">
+        <div class="question-status">
+          <span class="status-badge" :class="question.question_status === 'OPEN' ? 'status-open' : 'status-closed'">
+            {{ question.question_status === 'OPEN' ? $t("m.Community_Question_Open") : $t("m.Community_Question_Closed")
+            }}
+          </span>
+        </div>
+        <div class="question-content">
+          <h4 class="question-title">{{ question.title }}</h4>
+          <div class="question-meta">
+            <span class="author">
+              <img class="avatar"
+                :src="question.author_avatar || 'https://cdn-icons-png.flaticon.com/512/473/473406.png'"
+                :alt="question.author_name" />
+              {{ question.author_name }}
+            </span>
+            <span class="comments" v-if="question.comment_count > 0">
+              <Icon type="ios-chatbubbles-outline"></Icon>
+              {{ question.comment_count }}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div v-if="questions.length === 0" class="empty-state">
+        <Icon type="ios-help-circle-outline" size="48"></Icon>
+        <p>{{ $t("m.Community_Question_No_Questions") }}</p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import api from "@oj/api";
+
+export default {
+  name: "QuestionList",
+  data() {
+    return {
+      questions: [],
+      isLoading: false,
+    };
+  },
+  mounted() {
+    this.fetchQuestions();
+  },
+  methods: {
+    async fetchQuestions() {
+      this.isLoading = true;
+      try {
+        const res = await api.getCommunityPostList(0, 5, 'QUESTION', 'OPEN');
+        this.questions = res.data.data.results;
+      } catch (err) {
+        console.error("Failed to fetch questions:", err);
+      } finally {
+        this.isLoading = false;
+      }
+    },
+    goToQuestion(questionId) {
+      this.$router.push({ name: "community-detail", params: { postId: questionId } });
+    },
+  },
+};
+</script>
+
+<style lang="less" scoped>
+.question-list-widget {
+  background: white;
+  border-radius: 12px;
+  border: 1px solid #e8ecef;
+  overflow: hidden;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+  transition: all 0.3s ease;
+
+  &:hover {
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+  }
+}
+
+.widget-header {
+  padding: 20px;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+  text-align: center;
+
+  .widget-title {
+    margin: 0 0 8px;
+    font-size: 18px;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+  }
+
+  .widget-subtitle {
+    margin: 0;
+    font-size: 13px;
+    opacity: 0.9;
+    font-weight: 400;
+  }
+}
+
+.question-items {
+  max-height: 500px;
+  overflow-y: auto;
+  overflow-x: hidden;
+
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: #f8f9fa;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: #d5dce0;
+    border-radius: 3px;
+
+    &:hover {
+      background: #bdc3c7;
+    }
+  }
+}
+
+.question-item {
+  padding: 16px;
+  border-bottom: 1px solid #f0f3f7;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  display: flex;
+  gap: 12px;
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  &:hover {
+    background: #f8f9fa;
+
+    .question-title {
+      color: #3498db;
+    }
+  }
+}
+
+.question-status {
+  flex-shrink: 0;
+}
+
+.status-badge {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 12px;
+  font-size: 11px;
+  font-weight: 600;
+  white-space: nowrap;
+
+  &.status-open {
+    background: #FFF3E0;
+    color: #F57C00;
+  }
+
+  &.status-closed {
+    background: #E8F5E9;
+    color: #43A047;
+  }
+}
+
+.question-content {
+  flex: 1;
+  min-width: 0;
+}
+
+.question-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: #2c3e50;
+  margin: 0 0 8px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  line-height: 1.4;
+  transition: color 0.3s ease;
+}
+
+.question-meta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 12px;
+  color: #95a5a6;
+
+  span {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .ivu-icon {
+    font-size: 13px;
+  }
+
+  .avatar {
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    object-fit: cover;
+    display: flex;
+  }
+}
+
+.empty-state {
+  padding: 40px 20px;
+  text-align: center;
+  color: #bdc3c7;
+
+  .ivu-icon {
+    margin-bottom: 12px;
+    opacity: 0.5;
+  }
+
+  p {
+    margin: 0;
+    font-size: 14px;
+  }
+}
+</style>


### PR DESCRIPTION
# Changelog
백엔드
- `PostAPIView`에서 `question_status`를 쿼리 파라미터로 받아 미해결 질문 & 해결된 질문을 선택할 수 있도록 수정하였습니다.

프론트엔드
- 커뮤니티 페이지에서 미해결된 질문들을 모아 보여주는 컴포넌트 `QuestionList.vue`를 구현하였습니다.
  - `getCommunityList()` 에 `post_type`과 `question_status`를 매개변수로 전달하여 미해결된 질문만 가져오도록 구현하였습니다.
  - i18n 언어팩에 관련 단어들을 추가하였습니다.

# Testing
<img width="1728" height="1117" alt="Screenshot 2025-11-04 at 4 08 29 PM" src="https://github.com/user-attachments/assets/78669604-4c8b-450c-9110-86fc2638bd99" />

# Ops Impact
N/A

# Version Compatibility
N/A