### PR TITLE
#438 게시글 수정 관련 메소드 리팩토링

### DIFF
--- a/backend/community/serializers.py
+++ b/backend/community/serializers.py
@@ -148,9 +148,4 @@ class PostUpdateSerializer(serializers.Serializer):
     title = serializers.CharField(max_length=200, required=False)
     content = serializers.CharField(required=False)
     post_type = serializers.ChoiceField(choices=Post.PostType.choices, required=False)
-
-
-class PostStatusUpdateSerializer(serializers.Serializer):
-    """질문 게시글 상태 수정을 위한 Serializer"""
-
-    question_status = serializers.ChoiceField(choices=Post.QuestionStatus.choices)
+    question_status = serializers.ChoiceField(choices=Post.QuestionStatus.choices, required=False)

--- a/backend/community/urls/oj.py
+++ b/backend/community/urls/oj.py
@@ -1,6 +1,6 @@
 from django.conf.urls import url
 
-from ..views.oj import (CommentAPIView, CommentDetailAPIView, PostAPIView, PostDetailAPIView, PostStatusUpdateAPIView)
+from ..views.oj import (CommentAPIView, CommentDetailAPIView, PostAPIView, PostDetailAPIView)
 
 urlpatterns = [
     url(
@@ -12,11 +12,6 @@ urlpatterns = [
         r"^community/posts/(?P<post_id>\d+)/?$",
         PostDetailAPIView.as_view(),
         name="community_post_detail",
-    ),
-    url(
-        r"^community/posts/(?P<post_id>\d+)/status/?$",
-        PostStatusUpdateAPIView.as_view(),
-        name="community_post_status",
     ),
     url(
         r"^community/posts/(?P<post_id>\d+)/comments/?$",

--- a/backend/community/views/oj.py
+++ b/backend/community/views/oj.py
@@ -6,7 +6,7 @@ from utils.api import APIView, validate_serializer
 
 from ..models import Comment, Post
 from ..serializers import (CommentSerializer, CreatePostSerializer, PostListSerializer, PostDetailSerializer,
-                           PostStatusUpdateSerializer, PostUpdateSerializer)
+                           PostUpdateSerializer)
 
 
 class PostAPIView(APIView):
@@ -130,7 +130,7 @@ class PostDetailAPIView(APIView):
 
     @validate_serializer(PostUpdateSerializer)
     @login_required
-    def put(self, request, post_id):
+    def patch(self, request, post_id):
         """특정 게시글을 수정합니다."""
         post = self.get_post(post_id)
         if not post:
@@ -164,29 +164,6 @@ class PostDetailAPIView(APIView):
 
         post.delete()
         return self.success()
-
-
-class PostStatusUpdateAPIView(APIView):
-    """질문 게시글 상태 변경 API"""
-
-    @validate_serializer(PostStatusUpdateSerializer)
-    @login_required
-    def post(self, request, post_id):
-        """질문 게시글의 상태를 변경합니다."""
-        try:
-            post = Post.objects.get(id=post_id)
-        except Post.DoesNotExist:
-            return self.error("Post does not exist")
-
-        if post.post_type != Post.PostType.QUESTION:
-            return self.error("This is not a question post.")
-
-        if post.author != request.user and not request.user.is_super_admin():
-            return self.error("No permission to change status of this post")
-
-        post.question_status = request.data["question_status"]
-        post.save()
-        return self.success(PostDetailSerializer(post).data)
 
 
 class CommentAPIView(APIView):

--- a/frontend/src/pages/oj/api.js
+++ b/frontend/src/pages/oj/api.js
@@ -436,7 +436,7 @@ export default {
   },
 
   updateCommunityPost(postId, post) {
-    return ajax(`community/posts/${postId}`, "put", {
+    return ajax(`community/posts/${postId}`, "patch", {
       data: post,
     })
   },


### PR DESCRIPTION
# Changelog
- 게시글의 질문 상태(OPEN or CLOSED)를 수정하는 API View `PostStatusUpdateAPIView`는 게시글의 특정 필드를 변경하는 작업이므로 `PostAPIView` 와 통합되는 게 자연스럽습니다.
- `PostAPIView`의 PUT 메소드를 PATCH 메소드로 변경하고 `question_status`도 수정할 수 있도록 하였습니다.
  - PUT 메소드는 전체를 덮어쓰는 메소드이지만 PATCH 메소드는 일부 수정 메소드이기 때문에 더 자연스럽습니다.
- 테스트 코드를 수정하고, 프론트엔드의 API 함수도 PATCH로 수정하였습니다.

# Testing
- 유닛테스트 통과
<img width="659" height="164" alt="image" src="https://github.com/user-attachments/assets/ff530e7b-c8fc-46c7-8fdd-200cd1d4dea1" />

- 유닛테스트 커버리지
<img width="385" height="50" alt="image" src="https://github.com/user-attachments/assets/76156f64-b05f-4f20-ac82-b164a03eb6d9" />

# Ops Impact
N/A

# Version Compatibility
N/A