### PR TITLE
#430 새로운 게시글에 대한 NEW 뱃지 구현

### DIFF
--- a/frontend/src/pages/oj/views/community/Community.vue
+++ b/frontend/src/pages/oj/views/community/Community.vue
@@ -19,6 +19,7 @@
               <div class="card-left">
                 <div class="post-meta">
                   <span class="post-id">#{{ post.id }}</span>
+                  <span v-if="isNewPost(post)" class="new-badge">NEW</span>
                   <span v-if="POST_TYPE[post.post_type]" class="post-type-label" :style="{
                     backgroundColor: POST_TYPE[post.post_type].color,
                     color: POST_TYPE[post.post_type].textColor
@@ -117,6 +118,17 @@ export default {
     },
   },
   methods: {
+    /**
+     * 게시글이 3일 이내에 작성되었는지 확인
+     */
+    isNewPost(post) {
+      if (!post || !post.created_at) return false;
+      const postDate = new Date(post.created_at);
+      const now = new Date();
+      const diffTime = Math.abs(now - postDate);
+      const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+      return diffDays <= 3;
+    },
     async fetchPosts() {
       this.isLoading = true
 
@@ -261,6 +273,30 @@ main {
       background: #f8f9fa;
       padding: 4px 10px;
       border-radius: 6px;
+    }
+
+    .new-badge {
+      font-size: 12px;
+      font-weight: 700;
+      color: #ffffff;
+      background: linear-gradient(135deg, #ff6b6b 0%, #ee5a6f 100%);
+      padding: 4px 10px;
+      border-radius: 12px;
+      white-space: nowrap;
+      animation: pulse 2s ease-in-out infinite;
+      box-shadow: 0 2px 8px rgba(255, 107, 107, 0.3);
+    }
+
+    @keyframes pulse {
+
+      0%,
+      100% {
+        transform: scale(1);
+      }
+
+      50% {
+        transform: scale(1.05);
+      }
     }
 
     .post-type-label {

--- a/frontend/src/pages/oj/views/community/PostDetail.vue
+++ b/frontend/src/pages/oj/views/community/PostDetail.vue
@@ -5,6 +5,7 @@
         <div class="title-section" v-if="!isEditing">
           <h1 class="post-title">{{ post.title }}</h1>
           <div class="badges-container">
+            <span v-if="isNewPost" class="new-badge">NEW</span>
             <span v-if="POST_TYPE[post.post_type]" class="post-type-badge" :style="{
               backgroundColor: POST_TYPE[post.post_type].color,
               color: POST_TYPE[post.post_type].textColor
@@ -48,7 +49,7 @@
                   :type="post.question_status === 'CLOSED' ? 'ios-checkmark-circle' : 'ios-checkmark-circle-outline'">
                 </Icon>
                 {{ post.question_status === 'CLOSED' ? $t('m.Community_Question_Reopen') :
-                  $t('m.Community_Question_Close') }}
+                $t('m.Community_Question_Close') }}
               </button>
               <button class="post-edit-btn" @click="enterEditMode">{{ $t('m.Community_Post_Edit') }}</button>
               <button class="post-delete-btn" @click="deletePost(post.id)">{{ $t('m.Community_Post_Delete') }}</button>
@@ -422,6 +423,17 @@ export default {
       return QUESTION_STATUS;
     },
     /**
+     * 게시글이 3일 이내에 작성되었는지 확인
+     */
+    isNewPost() {
+      if (!this.post || !this.post.created_at) return false;
+      const postDate = new Date(this.post.created_at);
+      const now = new Date();
+      const diffTime = Math.abs(now - postDate);
+      const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+      return diffDays <= 3;
+    },
+    /**
      * 현재 사용자가 게시글 작성자인지 확인
      */
     isAuthor() {
@@ -513,6 +525,30 @@ main {
   align-items: center;
   gap: 8px;
   flex-wrap: wrap;
+}
+
+.new-badge {
+  padding: 6px 14px;
+  border-radius: 12px;
+  font-size: 13px;
+  font-weight: 700;
+  white-space: nowrap;
+  color: #ffffff;
+  background: linear-gradient(135deg, #ff6b6b 0%, #ee5a6f 100%);
+  animation: pulse 2s ease-in-out infinite;
+  box-shadow: 0 2px 8px rgba(255, 107, 107, 0.3);
+}
+
+@keyframes pulse {
+
+  0%,
+  100% {
+    transform: scale(1);
+  }
+
+  50% {
+    transform: scale(1.05);
+  }
 }
 
 .post-type-badge {


### PR DESCRIPTION
# Changelog
- 게시글이 업로드 된지 3일 이하인 경우 NEW 뱃지를 표시하도록 개선하였습니다.
  - 약간의 pulse를 주어 사용자들이 쉽게 눈치챌 수 있도록 구현하였습니다.

# Testing
https://github.com/user-attachments/assets/7963b0bf-9190-4e96-ae24-1283baadb9a1

# Ops Impact
N/A

# Version Compatibility
N/A