### PR TITLE
#440 문제 풀이 탭에서 게시글이 표시되지 않는 버그 수정

### DIFF
--- a/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/ProblemCommunity.vue
+++ b/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/ProblemCommunity.vue
@@ -149,7 +149,10 @@ export default {
     }
   },
   mounted() {
-    this.fetchPosts()
+    // problem.id가 로드 된 후 fetchPosts 호출
+    if (this.problem && this.problem.id) {
+      this.fetchPosts()
+    }
   },
   computed: {
     ...mapGetters(["user"]),
@@ -159,6 +162,19 @@ export default {
     defaultAvatar() {
       return DEFAULT_AVATAR
     },
+  },
+  watch: {
+    // NOTE: problem prop이 변경될 때 (로드될 때) fetchPosts 호출
+    // 이 로직이 없으면 문제 정보가 로드되기 전에 mounted 훅에서
+    // fetchPosts가 호출되어 문제 ID가 undefined 인 경우가 발생합니다.
+    'problem.id': {
+      handler(newVal) {
+        if (newVal) {
+          this.fetchPosts()
+        }
+      },
+      immediate: false
+    }
   },
   methods: {
     isNewPost(post) {
@@ -182,7 +198,7 @@ export default {
           this.query.limit,
           'QUESTION',
           null,
-          this.problemID,
+          this.problem.id,
           null
         )
         this.posts = res.data.data.results
@@ -218,7 +234,7 @@ export default {
           title: this.newPost.title,
           content: this.newPost.content,
           post_type: "QUESTION",
-          problem_id: this.problemID,
+          problem_id: this.problem.id,
         })
         this.$success(this.$i18n.t("m.Problem_Community_Create_Success"))
         this.showCreateModal = false


### PR DESCRIPTION
# Changelog
문제 풀이 페이지를 로드할 때 하위 컴포넌트 `ProblemCommunity`에 `problem` props로 전달이 즉시 되지 않아서, `fetchPosts`를 할 때  문제 번호가 빈 상태로 요청되는 버그가 발생하였습니다.

- `fetchPosts`를 mounted 훅 대신 `watch`를 사용하여 `problem.id`에 값이 들어왔을 때 호출되도록 변경하였습니다.
- `problemID`는 디스플레이 ID이고, 실제 Integer 아이디인 `this.problem.id`를 사용하여 요청을 보내도록 수정하였습니다.

# Testing
<img width="1728" height="1117" alt="Screenshot 2025-11-06 at 6 50 35 PM" src="https://github.com/user-attachments/assets/e0d276c2-068b-4c3e-90e5-94662c0e77e0" />

# Ops Impact
N/A

# Version Compatibility
N/A