### PR TITLE
#493 문제 생성 시 템플릿 생성 안되는 오류 수정

### DIFF
--- a/frontend/src/pages/admin/components/CodeMirror.vue
+++ b/frontend/src/pages/admin/components/CodeMirror.vue
@@ -1,0 +1,77 @@
+<template>
+  <codemirror
+    v-model="currentValue"
+    :options="options"
+    ref="editor"
+  ></codemirror>
+</template>
+<script>
+// import { codemirror } from 'vue-codemirror-lite'
+import { codemirror } from "vue-codemirror"
+import "codemirror/lib/codemirror.css"
+import "codemirror/mode/clike/clike.js"
+import "codemirror/mode/python/python.js"
+import "codemirror/theme/solarized.css"
+export default {
+  name: "CodeMirror",
+  data() {
+    return {
+      currentValue: "",
+      options: {
+        mode: "text/x-csrc",
+        lineNumbers: true,
+        lineWrapping: false,
+        theme: "solarized",
+        tabSize: 4,
+        line: true,
+        foldGutter: true,
+        gutters: ["CodeMirror-linenumbers", "CodeMirror-foldgutter"],
+        autofocus: true,
+      },
+    }
+  },
+  components: {
+    codemirror,
+  },
+  props: {
+    value: {
+      type: String,
+      default: "",
+    },
+    mode: {
+      type: String,
+      default: "text/x-csrc",
+    },
+  },
+  mounted() {
+    this.currentValue = this.value
+    this.$refs.editor.editor.setOption("mode", this.mode)
+  },
+  watch: {
+    value(val) {
+      if (this.currentValue !== val) {
+        this.currentValue = val
+      }
+    },
+    currentValue(newVal, oldVal) {
+      if (newVal !== oldVal) {
+        this.$emit("change", newVal)
+        this.$emit("input", newVal)
+      }
+    },
+    mode(newVal) {
+      this.$refs.editor.editor.setOption("mode", newVal)
+    },
+  },
+}
+</script>
+
+<style scoped>
+.CodeMirror {
+  height: auto !important;
+}
+.CodeMirror-scroll {
+  min-height: 300px;
+  max-height: 1000px;
+}
+</style>

--- a/frontend/src/pages/admin/views/problem/Problem.vue
+++ b/frontend/src/pages/admin/views/problem/Problem.vue
@@ -402,6 +402,7 @@
 <script>
 import Simditor from "../../components/Simditor"
 import Accordion from "../../components/Accordion"
+import CodeMirror from "../../components/CodeMirror"
 import api from "../../api"
 import { FIELD_MAP } from "../../../../utils/constants"
 
@@ -415,6 +416,7 @@ export default {
   components: {
     Simditor,
     Accordion,
+    CodeMirror,
   },
   data() {
     return {


### PR DESCRIPTION
# Changelog
- 문제 생성 시 언어별 템플릿이 생성되지 않는 오류를 수정하였습니다.
- `CodeMirror` 컴포넌트를 생성하고, 문제 생성 페이지에 Import 하였습니다.

# Testing
- 템플릿 등록
<img width="1728" height="1117" alt="Screenshot 2025-12-02 at 11 00 10 AM" src="https://github.com/user-attachments/assets/14c5f899-7a15-4b81-a61e-7dd6d27a7ffc" />

- 문제 풀이 에디터에서 템플릿 확인
<img width="1728" height="1117" alt="Screenshot 2025-12-02 at 11 01 15 AM" src="https://github.com/user-attachments/assets/7666c391-4e7f-4c67-8049-1e2200690674" />

# Ops Impact
N/A

# Version Compatibility
N/A