### PR TITLE
#501 K3s 환경에서 Redis StandAlone 구축

### DIFF
--- a/kubernetes/base/redis/README.md
+++ b/kubernetes/base/redis/README.md
@@ -1,0 +1,51 @@
+# Redis (Standalone) 배포 가이드
+
+이 문서는 Redis Operator를 사용하여 Standalone 모드의 Redis 인스턴스를 쿠버네티스 클러스터에 배포하는 방법을 안내합니다.
+
+### 핵심 파일
+
+- `redis.yaml`: Redis Operator를 통해 Redis Standalone 인스턴스를 생성하기 위한 Custom Resource(CR) 정의 파일입니다.
+
+---
+
+## 1. 사전 조건 (Prerequisites)
+
+이 설정을 적용하기 전에, 클러스터에 **Redis Operator**가 반드시 설치되어 있어야 합니다.
+
+#### 1-1. Helm 리포지토리 추가
+
+Opstree Redis Operator의 공식 Helm 차트 리포지토리를 추가합니다.
+
+```sh
+helm repo add ot-helm https://ot-container-kit.github.io/helm-charts/
+helm repo update
+```
+
+#### 1-2. Redis Operator 설치
+
+다음 명령어를 사용하여 클러스터에 Redis Operator를 설치합니다.
+
+```sh
+helm install redis-operator ot-helm/redis-operator
+```
+
+설치가 완료되면, Redis Custom Resource를 관리할 준비가 된 것입니다.
+
+---
+
+## 2. 배포 (Deployment)
+
+사전 조건이 충족되었다면, `redis.yaml` 파일을 클러스터에 적용하여 Redis 인스턴스를 배포할 수 있습니다. `redis.yaml` 파일은 현재 `kubernetes/base/redis/` 디렉토리에 있습니다.
+
+```sh
+kubectl apply -f ../backend/redis.yaml
+```
+
+> **관련 문서:** 더 자세한 정보는 [Redis Operator 공식 문서](https://redis-operator.opstree.dev/docs/getting-started/standalone/)를 참고하세요.
+
+---
+
+## 3. 향후 개선 사항 (TODO)
+
+- 현재 구성은 단일 파드로 운영되는 **Standalone 모드**입니다.
+- 향후 서비스 트래픽이 증가하거나 더 높은 수준의 가용성이 요구될 경우, **Sentinel 또는 Cluster 모드**로 전환하는 것을 검토해야 합니다. (Junwoo)

--- a/kubernetes/base/redis/redis.yaml
+++ b/kubernetes/base/redis/redis.yaml
@@ -1,0 +1,21 @@
+apiVersion: redis.redis.opstreelabs.in/v1beta2
+kind: Redis
+metadata:
+  name: redis-standalone
+spec:
+  kubernetesConfig:
+    image: quay.io/opstree/redis:v7.0.15
+    imagePullPolicy: IfNotPresent
+
+  storage:
+    volumeClaimTemplate:
+      spec:
+        storageClassName: longhorn
+        accessModes: ["ReadWriteOnce"] # Standalone은 단일 노드 점유이므로 RWO 사용
+        resources:
+          requests:
+            storage: 10Gi
+
+  podSecurityContext:
+    runAsUser: 1000 # Security: Root가 아닌 redis 기본 유저(ID 1000)로 프로세스 실행
+    fsGroup: 1000 # Permission: PVC 마운트 시 쓰기 권한을 1000번 그룹에 부여


### PR DESCRIPTION
# Changelog
- 테스트 환경에서 `helm`을 사용하여 Redis Operator를 구성하였습니다.
- Redis StandAlone CRD를 작성하였습니다.
  - Longhorn RWO 스토리지를 할당하고, 보안을 위해 Root 계정 대신 ID 1000 유저를 사용하도록 구성하였습니다.

# Testing
- Redis Standalone 구성 확인
```sh
$ kubectl get all
NAME                     READY   STATUS    RESTARTS   AGE
pod/redis-standalone-0   1/1     Running   0          42m

NAME                                  TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE
service/kubernetes                    ClusterIP   10.43.0.1      <none>        443/TCP    20h
service/redis-standalone              ClusterIP   10.43.95.190   <none>        6379/TCP   42m
service/redis-standalone-additional   ClusterIP   10.43.23.35    <none>        6379/TCP   42m
service/redis-standalone-headless     ClusterIP   None           <none>        6379/TCP   42m

NAME                                READY   AGE
statefulset.apps/redis-standalone   1/1     42m
```

- 포트포워딩을 통해 Redis 접속 테스트
```sh
$ kubectl port-forward service/redis-standalone 6380:6379 &
[1] 1056943

$ redis-cli -h 127.0.0.1 -p 6380
Handling connection for 6380
127.0.0.1:6380> keys *
(empty array)
127.0.0.1:6380>
```

# Ops Impact
N/A

# Version Compatibility
N/A