### PR TITLE
#506 Redis 데이터 영속성 보장을 위한 AOF 활성화

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -67,6 +67,8 @@ services:
   oj-redis:
     image: redis:4.0-alpine
     restart: always
+    # NOTE: Redis는 채점 요청을 저장하고 Celery의 메시지 큐로 사용되기 때문에 AOF 설정을 사용하여 데이터 영속성을 보장합니다.
+    command: redis-server --appendonly yes --appendfsync everysec
     volumes:
       - ../backend/data/redis:/data
 


### PR DESCRIPTION
# Changelog
- Redis 컨테이너를 실행할 때, `--appendonly yes --appendfsync everysec` 을 사용하여 AOF 옵션을 활성화하고, 매초마다 1초마다 쓰기 명령을 모아 동기화합니다. (기본값)

# Testing
- Redis 만 Docker-Compose로 실행한 뒤 AOF 활성화 여부 확인
<img width="1037" height="59" alt="image" src="https://github.com/user-attachments/assets/4632ce47-a1dd-405e-bd9b-7a11a1e7331b" />

- `mykey=myvalue` 데이터 삽입 후 AOF 파일 확인
<img width="977" height="282" alt="image" src="https://github.com/user-attachments/assets/d44c4fa6-b25f-447e-bec2-687d790233dc" />

# Ops Impact
N/A

# Version Compatibility
N/A