### PR TITLE
#519 백엔드 서버 GUNICORN 워커 개수 설정 로직 변경

### DIFF
--- a/backend/deploy/entrypoint.sh
+++ b/backend/deploy/entrypoint.sh
@@ -3,6 +3,8 @@
 APP=/app # 앱 데이터 경로 설정
 DATA=/data # 데이터 디렉토리 경로 설정
 
+DEFAULT_WORKER_NUM=2 # 기본 워커 프로세스 수 설정
+
 # log, config, test_case, avatar, banner, popup 디렉토리 생성
 mkdir -p $DATA/log $DATA/config $DATA/test_case $DATA/public/upload $DATA/public/avatar $DATA/public/website $DATA/public/banner $DATA/public/popup
 
@@ -20,14 +22,9 @@ if [ ! -f "$DATA/public/website/favicon.ico" ]; then
     cp data/public/website/favicon.ico $DATA/public/website
 fi
 
-# CPU 코어 수에 따른 최대 워커 프로세스 수 조정
+# MAX_WORKER_NUM 환경 변수가 설정되지 않은 경우 기본값 사용
 if [ -z "$MAX_WORKER_NUM" ]; then
-    export CPU_CORE_NUM=$(grep -c ^processor /proc/cpuinfo)
-    if [[ $CPU_CORE_NUM -lt 2 ]]; then
-        export MAX_WORKER_NUM=2
-    else
-        export MAX_WORKER_NUM=$(($CPU_CORE_NUM))
-    fi
+    MAX_WORKER_NUM=$DEFAULT_WORKER_NUM
 fi
 
 cd $APP


### PR DESCRIPTION
# Changelog
- 컨테이너 환경에서 `/proc/cpuinfo`는 컨테이너에 제한된 정확한 CPU 자원 정보를 읽어오지 못합니다.
- `DEFAULT_WORKER_NUM`을 정의하고, `MAX_WORKER_NUM` 환경 변수가 설정되지 않은 경우 기본값으로 사용되도록 설정하였습니다.

# Testing
`MAX_WORKER_NUM`을 설정하지 않은 경우 2개의 워커가 실행되는지 로그 확인

```
2025-12-16 08:44:39,189 INFO RPC interface 'supervisor' initialized
2025-12-16 08:44:39,189 CRIT Server 'inet_http_server' running without any HTTP authentication checking
2025-12-16 08:44:39,189 INFO supervisord started with pid 1
2025-12-16 08:44:40,196 INFO spawned: 'gunicorn' with pid 23
2025-12-16 08:44:45,439 INFO success: gunicorn entered RUNNING state, process has stayed up for > than 5 seconds (startsecs)
```

# Ops Impact
N/A

# Version Compatibility
N/A