### PR TITLE
#527 채점 서버 K3s Deployment 및 Service 생성

### DIFF
--- a/kubernetes/base/judge-server/deployment.yaml
+++ b/kubernetes/base/judge-server/deployment.yaml
@@ -1,0 +1,79 @@
+# kubernetes/base/judge/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: judge-server
+  labels:
+    app: judge-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: judge-server
+  template:
+    metadata:
+      labels:
+        app: judge-server
+    spec:
+      imagePullSecrets:
+        - name: regcred
+      containers:
+        - name: judge-server
+          image: registry.code-place-dev.site/code-place-dev/judge-server:1.0.3
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            capabilities:
+              drop:
+                - SETPCAP
+                - MKNOD
+                - NET_BIND_SERVICE
+                - SYS_CHROOT
+                - SETFCAP
+                - FSETID
+          ports:
+            - containerPort: 8080
+          resources:
+            requests:
+              memory: "500Mi"
+              cpu: "1000m"
+            limits:
+              memory: "1Gi"
+              cpu: "2000m" # TODO: 추후 채점 서버를 단일 프로세스로 변경하고, cgroup 종속성을 제거한 뒤 CPU Limit 제거
+          livenessProbe:
+            exec:
+              # 채점 서버 Heart Beat API를 호출하여 상태 확인
+              command:
+                - /app/.venv/bin/python3
+                - /app/service.py
+            initialDelaySeconds: 30
+            periodSeconds: 5
+          env:
+            - name: SERVICE_URL
+              value: "http://judge-server:8080"
+            - name: BACKEND_URL
+              value: "http://backend:8080/api/judge_server_heartbeat"
+            - name: TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: common-credentials
+                  key: JUDGE_SERVER_TOKEN
+          volumeMounts:
+            - name: vol-tmp
+              mountPath: /tmp
+            - name: vol-log
+              mountPath: /log
+            - name: vol-run
+              mountPath: /judger
+            - name: vol-testcase
+              mountPath: /test_case
+              readOnly: true
+      volumes:
+        - name: vol-tmp
+          emptyDir: {}
+        - name: vol-log
+          emptyDir: {}
+        - name: vol-run
+          emptyDir: {}
+        - name: vol-testcase
+          persistentVolumeClaim:
+            claimName: pvc-testcase

--- a/kubernetes/base/judge-server/service.yaml
+++ b/kubernetes/base/judge-server/service.yaml
@@ -1,0 +1,15 @@
+# kubernetes/base/judge/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: judge-server
+  labels:
+    app: judge-server
+spec:
+  selector:
+    app: judge-server
+  ports:
+    - name: api
+      port: 8080
+      targetPort: 8080
+      protocol: TCP

--- a/kubernetes/base/kustomization.yaml
+++ b/kubernetes/base/kustomization.yaml
@@ -13,10 +13,12 @@ resources:
   # Application Services
   - ./backend/service.yaml
   - ./frontend/service.yaml
+  - ./judge-server/service.yaml
 
   # Application Deployments
   - ./backend/deployment.yaml
   - ./frontend/deployment.yaml
+  - ./judge-server/deployment.yaml
 
   # Ingress Resources
   - ./frontend/ingress.yaml


### PR DESCRIPTION
# Changelog
- 채점 서버에 대한 Deployment 와 Service를 생성하였습니다.
- `securityContext.capabilities.drop`을 사용하여 기존 보안 권한을 유지하였습니다.
- 채점 서버 특성상 CPU Intensive한 작업을 수행하므로, `requests.CPU=1`, `limits.CPU=2`로 설정하였습니다.
- Kustomization 파일에 채점 서버의 Deployment, Service를 추가하였습니다.

# Testing
- K3s 에 Deployment 생성 후 로그 확인
```
$ k logs -f pod/judge-server-67997b8844-wn5cp -n code-place-dev
+ rm -rf /judger/*
+ mkdir -p /judger/run /judger/spj
+ chown compiler:code /judger/run
+ chmod 711 /judger/run
+ chown compiler:spj /judger/spj
+ chmod 710 /judger/spj
+ DEFAULT_WORKER_NUM=4
+ [ -z  ]
+ [ -f /sys/fs/cgroup/cpu.max ]
+ cat /sys/fs/cgroup/cpu.max
+ CPU_MAX=200000 100000
+ [ 200000 100000 != max ]
+ echo 200000 100000
+ cut -d  -f1
+ CPU_QUOTA=200000
+ echo 200000 100000
+ cut -d  -f2
+ CPU_PERIOD=100000
+ [ -n 200000 ]
+ [ -n 100000 ]
+ [ 100000 -gt 0 ]
+ export WORKER_NUM=2
+ [ -z 2 ]
+ [ 2 -eq 0 ]
+ exec .venv/bin/gunicorn server:app --workers 2 --threads 4 --error-logfile /log/gunicorn.log --bind 0.0.0.0:8080
```

- describe에 liveness 체크
```
...
Liveness:  exec [/app/.venv/bin/python3 /app/service.py] delay=30s timeout=1s period=5s #success=1 #failure=3
...
Conditions:
  Type                        Status
  PodReadyToStartContainers   True
  Initialized                 True
  Ready                       True
  ContainersReady             True
  PodScheduled                True
```

- 관리자 화면에서 채점 서버 정보 확인
<img width="1363" height="304" alt="image" src="https://github.com/user-attachments/assets/37002d43-039b-4558-9289-247a3cd49178" />

# Ops Impact
N/A

# Version Compatibility
N/A