### PR TITLE
#517 프론트엔드 NginX Conf 파일 K3s로 이전

### DIFF
--- a/frontend/deploy/entrypoint.sh
+++ b/frontend/deploy/entrypoint.sh
@@ -4,7 +4,8 @@ APP=/app
 DIST=/usr/share/nginx/html
 
 # Nginx 구성파일의 심볼릭 링크 생성, Https 강제 설정 여부에 따라 다름. default는 false
-cd $APP/deploy/nginx
+# K3s 환경에서 /kube_nginx 폴더 사용 (기존 /nginx 폴더는 Docker Swarm 용으로 Deprecated)
+cd $APP/deploy/kube_nginx
 ln -sf locations.conf https_locations.conf
 if [ -z "$FORCE_HTTPS" ]; then
     ln -sf locations.conf http_locations.conf
@@ -15,8 +16,8 @@ fi
 echo "Using SERVER_NAME: $SERVER_NAME"
 
 # 동적으로 server_name 변경
-sed -i "s/__SERVER_NAME__/$SERVER_NAME/g" /app/deploy/nginx/nginx.conf
-sed -i "s/__SERVER_NAME__/$SERVER_NAME/g" /app/deploy/nginx/ssl_config.conf
+sed -i "s/__SERVER_NAME__/$SERVER_NAME/g" /app/deploy/kube_nginx/nginx.conf
+# sed -i "s/__SERVER_NAME__/$SERVER_NAME/g" /app/deploy/nginx/ssl_config.conf
 
 # static contents 전송을 위한 CDN 호스트 설정
 cd $DIST
@@ -28,4 +29,4 @@ fi
 
 cd $APP
 
-exec nginx -c /app/deploy/nginx/nginx.conf
+exec nginx -c /app/deploy/kube_nginx/nginx.conf


### PR DESCRIPTION
# Changelog
- 프론트엔드 Nginx 설정 파일을 `/kube_nginx`로 변경하였습니다.
- 기존에 사용하던 Docker Swarm 전용 `/nginx` 와 혼란 방지를 위해 주석으로 설명을 작성하였습니다.

# Testing
- Docker Build 이후 `test/frontend`에 Push 하고, `code-place-dev` 네임스페이스에 배포 후 접속 여부 확인

# Ops Impact
N/A

# Version Compatibility
N/A