### PR TITLE
#538 Traefik 인증서 영속성 추가 및 TLS Challenge로 변경

### DIFF
--- a/kubernetes/setup/traefik/traefik-config.yaml
+++ b/kubernetes/setup/traefik/traefik-config.yaml
@@ -8,12 +8,17 @@ spec:
     additionalArguments:
       - "--certificatesresolvers.default.acme.email=<EMAIL_ADDRESS>"
       - "--certificatesresolvers.default.acme.storage=/data/acme.json"
-      - "--certificatesresolvers.default.acme.httpchallenge.entrypoint=web"
+      - "--certificatesresolvers.default.acme.tlschallenge=true" # 443 포트를 통해 인증
+
+    service:
+      enabled: true
+      type: LoadBalancer
+      annotations:
+        kube-vip.io/loadbalancerIPs: <가상 IP>
+
     ports:
       web:
-        # NOTE: Traefik Helm Chart v34부터는 `redirections` 사용 (참고: https://newreleases.io/project/github/traefik/traefik-helm-chart/release/v34.0.0)
         redirections:
-          # HTTP 요청을 HTTPS로 리디렉션
           entryPoint:
             to: websecure
             scheme: https
@@ -21,3 +26,31 @@ spec:
       websecure:
         tls:
           enabled: true
+
+    persistence:
+      enabled: true
+      name: data
+      accessMode: ReadWriteMany # 여러 노드에서 읽기/쓰기가 가능하도록 설정
+      size: 128Mi
+      storageClass: "longhorn"
+      path: /data
+
+    # 권한 문제 해결을 위한 initContainer 및 podSecurityContext 설정
+    # acme.json 파일의 권한을 600으로 설정하고 소유자를 Traefik 사용자(UID 65532)로 변경
+    # acme.json이 없는 경우 빈 파일을 생성
+    deployment:
+      initContainers:
+        - name: volume-permissions
+          image: busybox:latest
+          command:
+            - "sh"
+            - "-c"
+            - |
+              touch /data/acme.json
+              chmod 600 /data/acme.json
+              chown 65532:65532 /data/acme.json
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      podSecurityContext:
+        fsGroup: 65532


### PR DESCRIPTION
# Changelog
- Traefik의 서비스가 External IP를 할당받을 수 있도록 `annotations.kube-vip.io/loadBalancerIPs`를 추가하였습니다. (가상 IP 할당)
- Longhorn RWX PVC를 생성하여 Traefik 파드가 실행되는 노드가 변경되더라도 동일한 인증서를 지속해서 사용할 수 있도록 변경하였습니다.
- `/data/acme.json`의 권한이 600이 아닌 경우 Traefik에서 에러가 발생하기 때문에 컨테이너가 시작됐을 때 권한을 설정하는 `deployment.initContainers`를 구성하였습니다.

# Testing
- Traefik 파드 로그
```
$ k logs -f pod/traefik-xxxxxx -n kube-system
Defaulted container "traefik" out of: traefik, volume-permissions (init)
2025-12-24T23:03:15Z INF Traefik version 3.5.1 built on 2025-08-27T09:13:51Z version=3.5.1
2025-12-24T23:03:15Z INF
Stats collection is disabled.
Help us improve Traefik by turning this feature on :)
More details on: https://doc.traefik.io/traefik/contributing/data-collection/

2025-12-24T23:03:15Z INF Starting provider aggregator *aggregator.ProviderAggregator
2025-12-24T23:03:15Z INF Starting provider *crd.Provider
2025-12-24T23:03:15Z INF Starting provider *acme.ChallengeTLSALPN
2025-12-24T23:03:15Z INF Starting provider *traefik.Provider
2025-12-24T23:03:15Z INF Starting provider *ingress.Provider
2025-12-24T23:03:15Z INF label selector is: "" providerName=kubernetescrd
2025-12-24T23:03:15Z INF Creating in-cluster Provider client providerName=kubernetescrd
2025-12-24T23:03:15Z INF ingress label selector is: "" providerName=kubernetes
2025-12-24T23:03:15Z INF Creating in-cluster Provider client providerName=kubernetes
2025-12-24T23:03:15Z INF Starting provider *acme.Provider
2025-12-24T23:03:15Z INF Testing certificate renew... acmeCA=https://acme-v02.api.letsencrypt.org/directory providerName=default.acme
2025-12-24T23:03:18Z INF Register... providerName=default.acme
2025-12-24T23:13:17Z WRN A new release of Traefik has been found: 3.6.5. Please consider updating.
2025-12-25T23:03:15Z INF Testing certificate renew... acmeCA=https://acme-v02.api.letsencrypt.org/directory providerName=default.acme
2025-12-25T23:03:17Z WRN A new release of Traefik has been found: 3.6.5. Please consider updating.
2025-12-26T23:03:15Z INF Testing certificate renew... acmeCA=https://acme-v02.api.letsencrypt.org/directory providerName=default.acme
2025-12-26T23:03:18Z WRN A new release of Traefik has been found: 3.6.5. Please consider updating.
```

- Traefik용 Longhorn PVC 조회
```
$ k get pvc -n kube-system
NAME      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   VOLUMEATTRIBUTESCLASS   AGE
traefik   Bound    pvc-9bcae9fb-305b-4fc7-a870-515a7c54e34d   128Mi      RWX            longhorn       <unset>                 2d7h
```

- `code.pusan.ac.kr` 인증서 조회 결과
<img width="355" height="381" alt="image" src="https://github.com/user-attachments/assets/4a3f17b8-31cc-40c2-89bf-84186ace9832" />

# Ops Impact
N/A

# Version Compatibility
N/A