### PR TITLE
#568 fix: 공지사항 텍스트 클릭 시 목록으로 라우팅되는 문제 해결

### DIFF
--- a/frontend/src/pages/oj/views/home/Notice/HomeNoticeBox.vue
+++ b/frontend/src/pages/oj/views/home/Notice/HomeNoticeBox.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="noticeBox">
     <div class="noticeBoxHeader">
-      <span @click="handleRoute('notice')">공지사항</span>
+      <span>공지사항</span>
     </div>
     <div>
       <div class="announcement-header csep" @click="goAnnouncement('')">
@@ -24,8 +24,14 @@
         <span>{{ $t("m.No_Announcements") }}</span>
       </div>
       <ul class="announcements-container" key="list" v-else>
-        <HomeNoticeItem v-for="(announcement, idx) in csepAnnouncements" v-if="idx < 3" :key="announcement.title"
-          :announcement="announcement" :isCSEP="true" :isSW="false">
+        <HomeNoticeItem
+          v-for="(announcement, idx) in csepAnnouncements"
+          v-if="idx < 3"
+          :key="announcement.title"
+          :announcement="announcement"
+          :isCSEP="true"
+          :isSW="false"
+        >
         </HomeNoticeItem>
       </ul>
     </div>
@@ -50,8 +56,14 @@
         <span>{{ $t("m.No_Announcements") }}</span>
       </div>
       <ul class="announcements-container" key="list" v-else>
-        <HomeNoticeItem v-for="(announcement, idx) in swAnnouncements" v-if="idx < 5" :key="announcement.title"
-          :announcement="announcement" :isCSEP="false" :isSW="true">
+        <HomeNoticeItem
+          v-for="(announcement, idx) in swAnnouncements"
+          v-if="idx < 5"
+          :key="announcement.title"
+          :announcement="announcement"
+          :isCSEP="false"
+          :isSW="true"
+        >
         </HomeNoticeItem>
       </ul>
     </div>
@@ -119,9 +131,6 @@ export default {
     },
     goSW() {
       window.open(this.swUrl)
-    },
-    handleRoute(route) {
-      this.$router.push({ name: route })
     },
     goAnnouncement(announcement) {
       this.$router.push({


### PR DESCRIPTION
close #568 

# Changelog

### 프론트엔드 
- 공지사항 텍스트를 클릭 시 공지사항 목록으로 연결되는 오류 해결
- span 내 메서드 핸들러로 이동하게 작성되어 있는 코드를 해당 코드 삭제로 해결

# Testing

- **기존 화면** : 공지사항 클릭 시 목록으로 이동

https://github.com/user-attachments/assets/49a0c3e0-c6d7-4b7f-876e-9e5b507d898e

- **수정 화면** : 공지사항을 클릭해도 이동하지 않음.

https://github.com/user-attachments/assets/bbaaa4c7-8cd8-4cd2-98e9-7503b2831fc4


# Ops Impact

N/A

# Version Compatibility

N/A
