### PR TITLE
#587 문제 풀이/커뮤니티 페이지 드롭다운 필터 UI 정렬 오류

### DIFF
--- a/frontend/src/pages/oj/views/community/Community.vue
+++ b/frontend/src/pages/oj/views/community/Community.vue
@@ -716,7 +716,6 @@ main {
 }
 
 /deep/ .community-dropdown-menu .ivu-dropdown-item {
-  text-align: center;
   min-width: 100%;
   width: 100%;
 }

--- a/frontend/src/pages/oj/views/problem/problemList/problemListComponent/ProblemListTableHeader.vue
+++ b/frontend/src/pages/oj/views/problem/problemList/problemListComponent/ProblemListTableHeader.vue
@@ -185,7 +185,6 @@ export default {
   }
 
   /deep/ .problem-dropdown-menu .ivu-dropdown-item {
-    text-align: center;
     min-width: 100%;
     width: 100%;
   }


### PR DESCRIPTION
# Changelog

1. 드롭다운 박스와 메뉴 사이에 여백을 두고, 텍스트를 중앙정렬하여 통일된 UI를 제공합니다.
* 드롭다운 박스와 메뉴의 너비를 통일하려고 하였으나, 드롭다운 박스의 너비는 텍스트의 길이에 따라 유동적으로 변화하기에 일관성 측면에서 떨어진다고 생각하여 제거하였습니다. 

# Testing

<img width="1792" height="1120" alt="스크린샷 2026-03-09 오후 4 07 05" src="https://github.com/user-attachments/assets/97ff9a11-5701-4270-b732-091f8a517802" />
<img width="1792" height="1120" alt="스크린샷 2026-03-09 오후 4 07 30" src="https://github.com/user-attachments/assets/0d7a1827-9e5f-4580-8ec4-fb9c9167ad7c" />

- 문제 풀이 페이지 및 커뮤니티 페이지 접속 시 상단에 보이는 필터링 박스의 UI 개선
- 여백 및 텍스트 중앙정렬로 각 메뉴별 통일된 디자인 유지

# Ops Impact
N/A

# Version Compatibility
N/A