### PR TITLE
#601 vLLM Kubernetes 리소스 및 배포 가이드 추가

### DIFF
--- a/kubernetes/base/vllm/README.md
+++ b/kubernetes/base/vllm/README.md
@@ -1,0 +1,54 @@
+# vLLM 배포 가이드
+
+현재 `vLLM`은 `dev` 오버레이에서만 배포됩니다.
+
+- `dev`: 포함됨
+- `prod`: 포함되지 않음
+
+## 전제 조건
+
+- 클러스터에 NVIDIA device plugin 이 설치되어 있어야 합니다.
+- `vLLM`을 띄울 GPU 노드 정확히 1대에만 아래 라벨이 붙어 있어야 합니다.
+
+```bash
+kubectl label node <gpu-node-name> workload.code-place.ai/vllm=true
+```
+
+- `dev` 오버레이에는 `vllm-hf-cache` PVC 가 포함되어 있습니다.
+- Longhorn 이 정상 동작하면 PVC 는 자동 생성됩니다.
+
+## 배포
+
+```bash
+kustomize build kubernetes/overlays/dev | kubectl apply -f -
+```
+
+## 확인
+
+```bash
+kubectl get pod -n code-place-dev -o wide | grep vllm
+kubectl get svc -n code-place-dev vllm
+kubectl describe pod -n code-place-dev -l app=vllm
+```
+
+정상 배포되면 클러스터 내부에서는 `http://vllm.code-place-dev.svc.cluster.local:8000` 또는 같은 네임스페이스 안에서 `http://vllm:8000` 으로 접근할 수 있습니다.
+
+## 현재 설정
+
+- 이미지: `vllm/vllm-openai:v0.18.1-cu130`
+- 모델: `Qwen/Qwen2.5-Coder-7B-Instruct`
+- 포트: `8000`
+- 주요 옵션: `--dtype auto`, `--gpu-memory-utilization 0.9`, `--max-model-len 4096`, `--kv-cache-dtype fp8`, `--calculate-kv-scales`, `--enable-prefix-caching`, `--enable-chunked-prefill`, `--max-num-seqs 60`
+- 리소스: `cpu: 16`, `memory: 64Gi`, `nvidia.com/gpu: 1`
+- PVC: `vllm-hf-cache`, `storageClassName: longhorn`, `20Gi`, `ReadWriteOnce`
+
+## 운영 메모
+
+- `strategy: Recreate` 를 사용하므로 단일 replica 와 RWO PVC 조합에서 교체가 단순합니다.
+- `startupProbe` 는 첫 모델 다운로드와 초기 로딩 시간을 길게 허용합니다.
+- `readinessProbe` 가 통과하기 전까지는 서비스 트래픽을 받지 않습니다.
+- `livenessProbe` 가 계속 실패하면 쿠버네티스가 컨테이너를 재시작합니다.
+- `Service` 는 `ClusterIP` 이므로 외부에 직접 노출되지 않습니다.
+- Longhorn replica 수는 YAML 에서 고정하지 않고, 필요하면 Longhorn UI 에서 직접 조정하는 전제를 둡니다.
+- `max-num-seqs=60` 은 처리량 위주 값이라, 메모리 압박이나 OOM 이 보이면 가장 먼저 낮춰야 합니다.
+- 더 보수적으로 운영하려면 이미지 tag 대신 digest 로 pin 하는 것이 가장 안전합니다.

--- a/kubernetes/base/vllm/README.md
+++ b/kubernetes/base/vllm/README.md
@@ -8,6 +8,8 @@
 ## 전제 조건
 
 - 클러스터에 NVIDIA device plugin 이 설치되어 있어야 합니다.
+- **GPU 아키텍처**: CUDA compute capability 8.0 이상 (A100, L40S, H100 등) 을 권장합니다.
+  - `cu130` 이미지는 NVIDIA 드라이버 **570.x 이상**이 필요합니다.
 - `vLLM`을 띄울 GPU 노드 정확히 1대에만 아래 라벨이 붙어 있어야 합니다.
 
 ```bash
@@ -38,17 +40,18 @@ kubectl describe pod -n code-place-dev -l app=vllm
 - 이미지: `vllm/vllm-openai:v0.18.1-cu130`
 - 모델: `Qwen/Qwen2.5-Coder-7B-Instruct`
 - 포트: `8000`
-- 주요 옵션: `--dtype auto`, `--gpu-memory-utilization 0.9`, `--max-model-len 4096`, `--kv-cache-dtype fp8`, `--calculate-kv-scales`, `--enable-prefix-caching`, `--enable-chunked-prefill`, `--max-num-seqs 60`
+- 주요 옵션: `--dtype auto`, `--gpu-memory-utilization 0.9`, `--max-model-len 4096`, `--enable-prefix-caching`, `--enable-chunked-prefill`, `--max-num-seqs 60`
 - 리소스: `cpu: 16`, `memory: 64Gi`, `nvidia.com/gpu: 1`
-- PVC: `vllm-hf-cache`, `storageClassName: longhorn`, `20Gi`, `ReadWriteOnce`
+- PVC: `vllm-hf-cache`, `storageClassName: longhorn`, `50Gi`, `ReadWriteOnce`
 
 ## 운영 메모
 
 - `strategy: Recreate` 를 사용하므로 단일 replica 와 RWO PVC 조합에서 교체가 단순합니다.
-- `startupProbe` 는 첫 모델 다운로드와 초기 로딩 시간을 길게 허용합니다.
+- `startupProbe` 는 첫 모델 다운로드와 초기 로딩 시간을 길게 허용합니다 (`periodSeconds: 10` × `failureThreshold: 180` = 최대 30분).
 - `readinessProbe` 가 통과하기 전까지는 서비스 트래픽을 받지 않습니다.
 - `livenessProbe` 가 계속 실패하면 쿠버네티스가 컨테이너를 재시작합니다.
 - `Service` 는 `ClusterIP` 이므로 외부에 직접 노출되지 않습니다.
 - Longhorn replica 수는 YAML 에서 고정하지 않고, 필요하면 Longhorn UI 에서 직접 조정하는 전제를 둡니다.
 - `max-num-seqs=60` 은 처리량 위주 값이라, 메모리 압박이나 OOM 이 보이면 가장 먼저 낮춰야 합니다.
+- fp8 KV 캐시 (`--kv-cache-dtype fp8`, `--calculate-kv-scales`) 는 CUDA compute capability **8.9 이상** (Ada Lovelace: L40S/RTX 4090, Hopper: H100) GPU 에서만 지원됩니다. 해당 아키텍처 미만의 GPU 에서 사용하려면 해당 옵션을 제거하고 기본값(auto) 을 사용하십시오.
 - 더 보수적으로 운영하려면 이미지 tag 대신 digest 로 pin 하는 것이 가장 안전합니다.

--- a/kubernetes/base/vllm/README.md
+++ b/kubernetes/base/vllm/README.md
@@ -8,8 +8,6 @@
 ## 전제 조건
 
 - 클러스터에 NVIDIA device plugin 이 설치되어 있어야 합니다.
-- **GPU 아키텍처**: CUDA compute capability 8.0 이상 (A100, L40S, H100 등) 을 권장합니다.
-  - `cu130` 이미지는 NVIDIA 드라이버 **570.x 이상**이 필요합니다.
 - `vLLM`을 띄울 GPU 노드 정확히 1대에만 아래 라벨이 붙어 있어야 합니다.
 
 ```bash
@@ -40,18 +38,17 @@ kubectl describe pod -n code-place-dev -l app=vllm
 - 이미지: `vllm/vllm-openai:v0.18.1-cu130`
 - 모델: `Qwen/Qwen2.5-Coder-7B-Instruct`
 - 포트: `8000`
-- 주요 옵션: `--dtype auto`, `--gpu-memory-utilization 0.9`, `--max-model-len 4096`, `--enable-prefix-caching`, `--enable-chunked-prefill`, `--max-num-seqs 60`
+- 주요 옵션: `--dtype auto`, `--gpu-memory-utilization 0.9`, `--max-model-len 4096`, `--kv-cache-dtype fp8`, `--calculate-kv-scales`, `--enable-prefix-caching`, `--enable-chunked-prefill`, `--max-num-seqs 60`
 - 리소스: `cpu: 16`, `memory: 64Gi`, `nvidia.com/gpu: 1`
-- PVC: `vllm-hf-cache`, `storageClassName: longhorn`, `50Gi`, `ReadWriteOnce`
+- PVC: `vllm-hf-cache`, `storageClassName: longhorn`, `30Gi`, `ReadWriteOnce`
 
 ## 운영 메모
 
 - `strategy: Recreate` 를 사용하므로 단일 replica 와 RWO PVC 조합에서 교체가 단순합니다.
-- `startupProbe` 는 첫 모델 다운로드와 초기 로딩 시간을 길게 허용합니다 (`periodSeconds: 10` × `failureThreshold: 180` = 최대 30분).
+- `startupProbe` 는 첫 모델 다운로드와 초기 로딩 시간을 길게 허용합니다.
 - `readinessProbe` 가 통과하기 전까지는 서비스 트래픽을 받지 않습니다.
 - `livenessProbe` 가 계속 실패하면 쿠버네티스가 컨테이너를 재시작합니다.
 - `Service` 는 `ClusterIP` 이므로 외부에 직접 노출되지 않습니다.
 - Longhorn replica 수는 YAML 에서 고정하지 않고, 필요하면 Longhorn UI 에서 직접 조정하는 전제를 둡니다.
 - `max-num-seqs=60` 은 처리량 위주 값이라, 메모리 압박이나 OOM 이 보이면 가장 먼저 낮춰야 합니다.
-- fp8 KV 캐시 (`--kv-cache-dtype fp8`, `--calculate-kv-scales`) 는 CUDA compute capability **8.9 이상** (Ada Lovelace: L40S/RTX 4090, Hopper: H100) GPU 에서만 지원됩니다. 해당 아키텍처 미만의 GPU 에서 사용하려면 해당 옵션을 제거하고 기본값(auto) 을 사용하십시오.
 - 더 보수적으로 운영하려면 이미지 tag 대신 digest 로 pin 하는 것이 가장 안전합니다.

--- a/kubernetes/base/vllm/deployment.yaml
+++ b/kubernetes/base/vllm/deployment.yaml
@@ -40,9 +40,6 @@ spec:
             - "0.9"
             - --max-model-len
             - "4096"
-            - --kv-cache-dtype
-            - fp8
-            - --calculate-kv-scales
             - --enable-prefix-caching
             - --max-num-seqs
             - "60"

--- a/kubernetes/base/vllm/deployment.yaml
+++ b/kubernetes/base/vllm/deployment.yaml
@@ -1,0 +1,93 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vllm
+  labels:
+    app: vllm
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  progressDeadlineSeconds: 1800
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: vllm
+  template:
+    metadata:
+      labels:
+        app: vllm
+    spec:
+      terminationGracePeriodSeconds: 180
+      nodeSelector:
+        workload.code-place.ai/vllm: "true"
+      securityContext:
+        fsGroup: 1000
+      containers:
+        - name: vllm
+          image: vllm/vllm-openai:v0.18.1-cu130
+          imagePullPolicy: IfNotPresent
+          args:
+            - --model
+            - Qwen/Qwen2.5-Coder-7B-Instruct
+            - --port
+            - "8000"
+            - --host
+            - 0.0.0.0
+            - --dtype
+            - auto
+            - --gpu-memory-utilization
+            - "0.9"
+            - --max-model-len
+            - "4096"
+            - --kv-cache-dtype
+            - fp8
+            - --calculate-kv-scales
+            - --enable-prefix-caching
+            - --max-num-seqs
+            - "60"
+            - --enable-chunked-prefill
+          ports:
+            - containerPort: 8000
+              name: http
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: "16"
+              memory: 64Gi
+              nvidia.com/gpu: "1"
+            limits:
+              cpu: "16"
+              memory: 64Gi
+              nvidia.com/gpu: "1"
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+            failureThreshold: 180
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            failureThreshold: 6
+          volumeMounts:
+            - name: hf-cache
+              mountPath: /root/.cache/huggingface
+      volumes:
+        - name: hf-cache
+          persistentVolumeClaim:
+            claimName: vllm-hf-cache

--- a/kubernetes/base/vllm/deployment.yaml
+++ b/kubernetes/base/vllm/deployment.yaml
@@ -40,6 +40,9 @@ spec:
             - "0.9"
             - --max-model-len
             - "4096"
+            - --kv-cache-dtype
+            - fp8
+            - --calculate-kv-scales
             - --enable-prefix-caching
             - --max-num-seqs
             - "60"

--- a/kubernetes/base/vllm/pvc.yaml
+++ b/kubernetes/base/vllm/pvc.yaml
@@ -8,4 +8,4 @@ spec:
   storageClassName: longhorn
   resources:
     requests:
-      storage: 50Gi
+      storage: 30Gi

--- a/kubernetes/base/vllm/pvc.yaml
+++ b/kubernetes/base/vllm/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: vllm-hf-cache
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 20Gi

--- a/kubernetes/base/vllm/pvc.yaml
+++ b/kubernetes/base/vllm/pvc.yaml
@@ -8,4 +8,4 @@ spec:
   storageClassName: longhorn
   resources:
     requests:
-      storage: 20Gi
+      storage: 50Gi

--- a/kubernetes/base/vllm/service.yaml
+++ b/kubernetes/base/vllm/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: vllm
+  labels:
+    app: vllm
+spec:
+  type: ClusterIP
+  selector:
+    app: vllm
+  ports:
+    - name: http
+      port: 8000
+      targetPort: http
+      protocol: TCP

--- a/kubernetes/overlays/dev/kustomization.yaml
+++ b/kubernetes/overlays/dev/kustomization.yaml
@@ -2,6 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - ../../base/vllm/pvc.yaml
+  - ../../base/vllm/service.yaml
+  - ../../base/vllm/deployment.yaml
   - ./secrets/pg-credentials.yaml
   - ./secrets/regcred.yaml
   - ./secrets/common-credentials.yaml


### PR DESCRIPTION
# Changelog

- vLLM 배포 리소스를 kubernetes/base/vllm/ 아래에 추가했습니다.
- vLLM은 현재 dev 오버레이에서만 배포되도록 구성했습니다.
- vLLM Deployment/Service/PVC와 관련 README를 정리했습니다.
- 기본 모델은 `Qwen/Qwen2.5-Coder-7B-Instruct`, 이미지는 `vllm/vllm-openai:v0.18.1-cu130` 으로 설정했습니다.
- PVC 크기를 20Gi에서 30Gi로 확장했습니다.
- `--kv-cache-dtype fp8` 및 `--calculate-kv-scales` 옵션을 포함합니다.

# Testing

N/A

# Ops Impact

- dev 환경에만 신규 vLLM 서비스가 추가됩니다.
- prod 영향은 없습니다.
- GPU 노드 라벨링이 필요합니다.
- DB 마이그레이션은 없습니다.
- PVC 크기가 30Gi이므로 Longhorn 스토리지 여유 공간을 사전에 확인해야 합니다.

# Version Compatibility

- vLLM 컨테이너는 v0.18.1-cu130 이미지와 호환되는 GPU/CUDA 환경이 필요합니다.