### PR TITLE
#597 대회 랭킹 페이지 오류 수정 및 디자인 개선

### DIFF
--- a/backend/contest/serializers.py
+++ b/backend/contest/serializers.py
@@ -9,7 +9,7 @@ from .models import ACMContestRank, OIContestRank
 class ContestUserSubmissionSummarySerializer(serializers.Serializer):
     user_id = serializers.IntegerField()
     username = serializers.CharField(allow_blank=True)
-    email = serializers.CharField(allow_blank=True)
+    email = serializers.EmailField(allow_blank=True, required=False)
     avatar = serializers.CharField(allow_blank=True)
     school = serializers.CharField(allow_blank=True)
     major = serializers.CharField(allow_blank=True)

--- a/backend/contest/serializers.py
+++ b/backend/contest/serializers.py
@@ -8,13 +8,13 @@ from .models import ACMContestRank, OIContestRank
 
 class ContestUserSubmissionSummarySerializer(serializers.Serializer):
     user_id = serializers.IntegerField()
-    username = serializers.CharField()
-    email = serializers.EmailField()
-    avatar = serializers.CharField()
-    school = serializers.CharField()
-    major = serializers.CharField()
+    username = serializers.CharField(allow_blank=True)
+    email = serializers.CharField(allow_blank=True)
+    avatar = serializers.CharField(allow_blank=True)
+    school = serializers.CharField(allow_blank=True)
+    major = serializers.CharField(allow_blank=True)
     submission_count = serializers.IntegerField()
-    last_submission_ip = serializers.CharField()
+    last_submission_ip = serializers.CharField(allow_blank=True)
 
 
 class CreateConetestSeriaizer(serializers.Serializer):

--- a/backend/contest/tests.py
+++ b/backend/contest/tests.py
@@ -237,6 +237,10 @@ class ContestParticipantsAPITest(APITestCase):
         self.assertEqual(participants[0]["username"], self.user.username)
         self.assertEqual(participants[0]["submission_count"], 2)
 
+    def test_participants_requires_contest_id(self):
+        resp = self.client.get(self.url)
+        self.assertFailed(resp, "Invalid parameter, contest_id is required")
+
     def test_participants_fallback_to_submission_username_when_user_is_missing(self):
         from submission.models import JudgeStatus, Submission
 

--- a/backend/contest/tests.py
+++ b/backend/contest/tests.py
@@ -1,6 +1,7 @@
 import copy
 from datetime import datetime, timedelta
 
+from django.conf import settings
 from django.utils import timezone
 
 from utils.api.tests import APITestCase
@@ -235,3 +236,33 @@ class ContestParticipantsAPITest(APITestCase):
         self.assertEqual(participants[0]["user_id"], self.user.id)
         self.assertEqual(participants[0]["username"], self.user.username)
         self.assertEqual(participants[0]["submission_count"], 2)
+
+    def test_participants_fallback_to_submission_username_when_user_is_missing(self):
+        from submission.models import JudgeStatus, Submission
+
+        Submission.objects.create(
+            user_id=self.user.id,
+            username="ghostuser",
+            language="C++",
+            code="test code",
+            problem_id=self.problem.id,
+            ip="127.0.0.1",
+            contest_id=self.contest.id,
+            result=JudgeStatus.PENDING,
+            statistic_info={"time_cost": "100", "memory_cost": "1024"},
+            shared=False,
+            first_failed_tc_idx=None,
+        )
+
+        self.user.delete()
+
+        resp = self.client.get(f"{self.url}?contest_id={self.contest.id}")
+        self.assertSuccess(resp)
+
+        participants = resp.data["data"]
+        self.assertEqual(len(participants), 1)
+        self.assertEqual(participants[0]["username"], "ghostuser")
+        self.assertEqual(participants[0]["email"], "")
+        self.assertEqual(participants[0]["avatar"], f"{settings.AVATAR_URI_PREFIX}/default.png")
+        self.assertEqual(participants[0]["school"], "")
+        self.assertEqual(participants[0]["major"], "")

--- a/backend/contest/tests.py
+++ b/backend/contest/tests.py
@@ -241,6 +241,10 @@ class ContestParticipantsAPITest(APITestCase):
         resp = self.client.get(self.url)
         self.assertFailed(resp, "Invalid parameter, contest_id is required")
 
+    def test_participants_rejects_invalid_contest_id(self):
+        resp = self.client.get(f"{self.url}?contest_id=abc")
+        self.assertFailed(resp, "Invalid parameter, contest_id is required")
+
     def test_participants_fallback_to_submission_username_when_user_is_missing(self):
         from submission.models import JudgeStatus, Submission
 

--- a/backend/contest/tests.py
+++ b/backend/contest/tests.py
@@ -181,3 +181,57 @@ class ContestRankAPITest(APITestCase):
     def get_contest_rank(self):
         resp = self.client.get(self.url + "?contest_id=" + self.acm_contest.id)
         self.assertSuccess(resp)
+
+
+class ContestParticipantsAPITest(APITestCase):
+
+    def setUp(self):
+        from problem.tests import DEFAULT_PROBLEM_DATA, ProblemCreateTestBase
+
+        self.create_school_fixtures(college_id=1, college_name="Test", department_id=1, department_name="Test")
+        self.admin = self.create_admin()
+        self.user = self.create_user(email="test@test.com", username="test", password="test1234!", login=False)
+        self.contest = Contest.objects.create(created_by=self.admin, **DEFAULT_CONTEST_DATA)
+        self.problem = ProblemCreateTestBase.add_problem(DEFAULT_PROBLEM_DATA, self.admin)
+        self.problem.contest_id = self.contest.id
+        self.problem.save()
+        self.url = self.reverse("contest_participants_api")
+
+    def test_participants_are_grouped_by_user_id(self):
+        from submission.models import JudgeStatus, Submission
+
+        Submission.objects.create(
+            user_id=self.user.id,
+            username="oldname",
+            language="C++",
+            code="test code",
+            problem_id=self.problem.id,
+            ip="127.0.0.1",
+            contest_id=self.contest.id,
+            result=JudgeStatus.PENDING,
+            statistic_info={"time_cost": "100", "memory_cost": "1024"},
+            shared=False,
+            first_failed_tc_idx=None,
+        )
+        Submission.objects.create(
+            user_id=self.user.id,
+            username="newname",
+            language="C++",
+            code="test code",
+            problem_id=self.problem.id,
+            ip="127.0.0.1",
+            contest_id=self.contest.id,
+            result=JudgeStatus.PENDING,
+            statistic_info={"time_cost": "100", "memory_cost": "1024"},
+            shared=False,
+            first_failed_tc_idx=None,
+        )
+
+        resp = self.client.get(f"{self.url}?contest_id={self.contest.id}")
+        self.assertSuccess(resp)
+
+        participants = resp.data["data"]
+        self.assertEqual(len(participants), 1)
+        self.assertEqual(participants[0]["user_id"], self.user.id)
+        self.assertEqual(participants[0]["username"], self.user.username)
+        self.assertEqual(participants[0]["submission_count"], 2)

--- a/backend/contest/tests.py
+++ b/backend/contest/tests.py
@@ -240,19 +240,34 @@ class ContestParticipantsAPITest(APITestCase):
     def test_participants_fallback_to_submission_username_when_user_is_missing(self):
         from submission.models import JudgeStatus, Submission
 
-        Submission.objects.create(
+        older_submission = Submission.objects.create(
             user_id=self.user.id,
-            username="ghostuser",
+            username="zzz_user",
             language="C++",
             code="test code",
             problem_id=self.problem.id,
-            ip="127.0.0.1",
+            ip="9.9.9.9",
             contest_id=self.contest.id,
             result=JudgeStatus.PENDING,
             statistic_info={"time_cost": "100", "memory_cost": "1024"},
             shared=False,
             first_failed_tc_idx=None,
         )
+        latest_submission = Submission.objects.create(
+            user_id=self.user.id,
+            username="aaa_user",
+            language="C++",
+            code="test code",
+            problem_id=self.problem.id,
+            ip="1.1.1.1",
+            contest_id=self.contest.id,
+            result=JudgeStatus.PENDING,
+            statistic_info={"time_cost": "100", "memory_cost": "1024"},
+            shared=False,
+            first_failed_tc_idx=None,
+        )
+        Submission.objects.filter(id=older_submission.id).update(create_time=timezone.now() - timedelta(minutes=1))
+        Submission.objects.filter(id=latest_submission.id).update(create_time=timezone.now())
 
         self.user.delete()
 
@@ -261,8 +276,9 @@ class ContestParticipantsAPITest(APITestCase):
 
         participants = resp.data["data"]
         self.assertEqual(len(participants), 1)
-        self.assertEqual(participants[0]["username"], "ghostuser")
+        self.assertEqual(participants[0]["username"], "aaa_user")
         self.assertEqual(participants[0]["email"], "")
         self.assertEqual(participants[0]["avatar"], f"{settings.AVATAR_URI_PREFIX}/default.png")
         self.assertEqual(participants[0]["school"], "")
         self.assertEqual(participants[0]["major"], "")
+        self.assertEqual(participants[0]["last_submission_ip"], "1.1.1.1")

--- a/backend/contest/views/oj.py
+++ b/backend/contest/views/oj.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.db.models import OuterRef, Count, Subquery, F, Max
 from django.http import HttpResponse
 from django.utils.timezone import now
@@ -158,7 +159,9 @@ class ContestParticipantsAPI(APIView):
         submissions = Submission.objects.filter(contest_id=contest_id)
 
         user_submissions = submissions.values('user_id').annotate(
-            submission_count=Count('id'), last_submission_ip=Max('ip')).order_by('user_id')
+            submission_count=Count('id'),
+            last_submission_ip=Max('ip'),
+            fallback_username=Max('username')).order_by('user_id')
 
         # UserProfile 정보 가져오기
         user_profiles = UserProfile.objects.filter(user_id__in=[sub['user_id'] for sub in user_submissions])
@@ -172,15 +175,20 @@ class ContestParticipantsAPI(APIView):
         for submission in user_submissions:
             user = user_dict.get(submission['user_id'])
             profile = user_profile_dict.get(submission['user_id'])
+            username = user.username if user else (submission['fallback_username'] or "")
+            email = user.email if user and user.email else ""
+            avatar = profile.avatar if profile else f"{settings.AVATAR_URI_PREFIX}/default.png"
+            school = profile.school if profile and profile.school else ""
+            major = profile.major if profile and profile.major else ""
             result.append({
                 'user_id': submission['user_id'],
-                'username': user.username if user else None,
-                'email': user.email if user else None,
-                'avatar': profile.avatar if profile else None,
-                'school': profile.school if profile else None,
-                'major': profile.major if profile else None,
+                'username': username,
+                'email': email,
+                'avatar': avatar,
+                'school': school,
+                'major': major,
                 'submission_count': submission['submission_count'],
-                'last_submission_ip': submission['last_submission_ip']
+                'last_submission_ip': submission['last_submission_ip'] or ""
             })
 
         serializer = ContestUserSubmissionSummarySerializer(result, many=True)

--- a/backend/contest/views/oj.py
+++ b/backend/contest/views/oj.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.db.models import OuterRef, Count, Subquery, F, Max
+from django.db.models import OuterRef, Count, Subquery
 from django.http import HttpResponse
 from django.utils.timezone import now
 from django.core.cache import cache
@@ -157,11 +157,12 @@ class ContestParticipantsAPI(APIView):
         contest_id = request.GET.get("contest_id")
 
         submissions = Submission.objects.filter(contest_id=contest_id)
+        latest_submission = submissions.filter(user_id=OuterRef('user_id')).order_by('-create_time', '-id')
 
         user_submissions = submissions.values('user_id').annotate(
             submission_count=Count('id'),
-            last_submission_ip=Max('ip'),
-            fallback_username=Max('username')).order_by('user_id')
+            last_submission_ip=Subquery(latest_submission.values('ip')[:1]),
+            fallback_username=Subquery(latest_submission.values('username')[:1])).order_by('user_id')
 
         # UserProfile 정보 가져오기
         user_profiles = UserProfile.objects.filter(user_id__in=[sub['user_id'] for sub in user_submissions])

--- a/backend/contest/views/oj.py
+++ b/backend/contest/views/oj.py
@@ -9,7 +9,7 @@ from utils.constants import CacheKey, CONTEST_PASSWORD_SESSION_KEY
 from utils.contest_ranking_writer import ContestRankingWriter
 from utils.shortcuts import datetime2str, check_is_id
 from account.models import AdminType, User, UserProfile
-from account.decorators import login_required, check_contest_permission, check_contest_password
+from account.decorators import login_required, check_contest_permission, check_contest_password, ensure_created_by
 
 from utils.constants import ContestRuleType, ContestStatus
 from ..models import ContestAnnouncement, Contest, OIContestRank, ACMContestRank
@@ -155,6 +155,14 @@ class ContestParticipantsAPI(APIView):
     @login_required
     def get(self, request):
         contest_id = request.GET.get("contest_id")
+        if not contest_id:
+            return self.error("Invalid parameter, contest_id is required")
+
+        try:
+            contest = Contest.objects.get(id=contest_id)
+            ensure_created_by(contest, request.user)
+        except Contest.DoesNotExist:
+            return self.error("Contest does not exist")
 
         submissions = Submission.objects.filter(contest_id=contest_id)
         latest_submission = submissions.filter(user_id=OuterRef('user_id')).order_by('-create_time', '-id')

--- a/backend/contest/views/oj.py
+++ b/backend/contest/views/oj.py
@@ -155,7 +155,7 @@ class ContestParticipantsAPI(APIView):
     @login_required
     def get(self, request):
         contest_id = request.GET.get("contest_id")
-        if not contest_id:
+        if not contest_id or not check_is_id(contest_id):
             return self.error("Invalid parameter, contest_id is required")
 
         try:

--- a/backend/contest/views/oj.py
+++ b/backend/contest/views/oj.py
@@ -157,7 +157,7 @@ class ContestParticipantsAPI(APIView):
 
         submissions = Submission.objects.filter(contest_id=contest_id)
 
-        user_submissions = submissions.values('user_id', 'username').annotate(
+        user_submissions = submissions.values('user_id').annotate(
             submission_count=Count('id'), last_submission_ip=Max('ip')).order_by('user_id')
 
         # UserProfile 정보 가져오기
@@ -174,7 +174,7 @@ class ContestParticipantsAPI(APIView):
             profile = user_profile_dict.get(submission['user_id'])
             result.append({
                 'user_id': submission['user_id'],
-                'username': submission['username'],
+                'username': user.username if user else None,
                 'email': user.email if user else None,
                 'avatar': profile.avatar if profile else None,
                 'school': profile.school if profile else None,

--- a/frontend/config/index.js
+++ b/frontend/config/index.js
@@ -3,11 +3,13 @@
 // see http://vuejs-templates.github.io/webpack for documentation.
 
 const path = require("path")
+const target = process.env.TARGET || "https://code.pusan.ac.kr"
+
 const commonProxy = {
   onProxyReq: (proxyReq, req, res) => {
-    proxyReq.setHeader("Referer", process.env.TARGET)
+    proxyReq.setHeader("Referer", target)
   },
-  target: process.env.TARGET,
+  target,
   changeOrigin: true,
 }
 

--- a/frontend/config/index.js
+++ b/frontend/config/index.js
@@ -3,13 +3,11 @@
 // see http://vuejs-templates.github.io/webpack for documentation.
 
 const path = require("path")
-const target = process.env.TARGET || "https://code.pusan.ac.kr"
-
 const commonProxy = {
   onProxyReq: (proxyReq, req, res) => {
-    proxyReq.setHeader("Referer", target)
+    proxyReq.setHeader("Referer", process.env.TARGET)
   },
-  target,
+  target: process.env.TARGET,
   changeOrigin: true,
 }
 

--- a/frontend/src/pages/oj/App.vue
+++ b/frontend/src/pages/oj/App.vue
@@ -42,7 +42,6 @@ export default {
   },
   mounted() {
     this.getWebsiteConfig()
-    this.init()
   },
   methods: {
     ...mapActions(["getWebsiteConfig", "changeDomTitle"]),

--- a/frontend/src/pages/oj/components/CustomTooltip.vue
+++ b/frontend/src/pages/oj/components/CustomTooltip.vue
@@ -12,7 +12,10 @@
 export default {
   name: "custom-tooltip",
   props: {
-    content: HTMLElement,
+    content: {
+      type: [String, Number],
+      default: "",
+    },
     placement: {
       type: String,
       default: "top",

--- a/frontend/src/pages/oj/views/contest/children/ACMContestRank.vue
+++ b/frontend/src/pages/oj/views/contest/children/ACMContestRank.vue
@@ -55,7 +55,9 @@
                 {{ rank.user.username }}
               </a>
             </td>
-            <td>{{ rank.accepted_number }}</td>
+            <td>
+              <span class="accepted-count-value">{{ rank.accepted_number }}</span>
+            </td>
             <td v-for="problem in contestProblems">
               <CustomTooltip
                 v-if="rank[problem.id].status === 'ac'"
@@ -260,5 +262,12 @@ export default {
 .problem-status.wa {
   background: #fff1eb;
   color: #c7512d;
+}
+
+.accepted-count-value {
+  font-size: 20px;
+  font-weight: 600;
+  line-height: 1;
+  color: #2f3c57;
 }
 </style>

--- a/frontend/src/pages/oj/views/contest/children/ACMContestRank.vue
+++ b/frontend/src/pages/oj/views/contest/children/ACMContestRank.vue
@@ -247,6 +247,8 @@ export default {
 .ACMRankContent {
   text-align: center;
   display: block;
+  border-collapse: collapse;
+  border-spacing: 0;
   padding-top: 50px;
   max-width: 928px;
   overflow-y: visible;
@@ -259,7 +261,7 @@ export default {
   }
   td {
     border-top: 1px solid rgba(0, 0, 0, 0.1);
-    padding: 10px 0px;
+    padding: 6px 8px;
   }
   tr {
     font-size: 1.05em;

--- a/frontend/src/pages/oj/views/contest/children/ACMContestRank.vue
+++ b/frontend/src/pages/oj/views/contest/children/ACMContestRank.vue
@@ -96,7 +96,7 @@
               :key="`acm-rank-problem-${rank.id || rank.user.id}-${problem.id}`"
             >
               <CustomTooltip
-                v-if="rank[problem.id].status === 'ac'"
+                v-if="rank[problem.id] && rank[problem.id].status === 'ac'"
                 :content="`${rank[problem.id].attempt_count}회 시도`"
                 placement="top"
               >
@@ -110,7 +110,7 @@
                 </div>
               </CustomTooltip>
               <div
-                v-else-if="rank[problem.id].status"
+                v-else-if="rank[problem.id] && rank[problem.id].status"
                 class="problem-status"
                 :class="rank[problem.id].status"
               >

--- a/frontend/src/pages/oj/views/contest/children/ACMContestRank.vue
+++ b/frontend/src/pages/oj/views/contest/children/ACMContestRank.vue
@@ -18,7 +18,7 @@
             {{ $t("m.Solved_Problems") }}
           </th>
           <th v-for="problem in contestProblems">
-            <CustomTooltip :content="problem._id" placement="top">
+            <CustomTooltip :content="problem.title" placement="top">
               <a
                 style="
                   color: #6ccbff;
@@ -57,26 +57,29 @@
             </td>
             <td>{{ rank.accepted_number }}</td>
             <td v-for="problem in contestProblems">
-              <div
-                v-if="rank[problem.id].isSet"
-                style="
-                  display: flex;
-                  flex-direction: column;
-                  align-items: center;
-                "
+              <CustomTooltip
+                v-if="rank[problem.id].status === 'ac'"
+                :content="`${rank[problem.id].attempt_count}회 시도`"
+                placement="top"
               >
-                <span
-                  style="
-                    font-size: 12px;
-                    background-color: rgb(128, 128, 128);
-                    padding: 2px 4px;
-                    border-radius: 5px;
-                    color: white;
-                  "
-                >
-                  {{ rank[problem.id].ac_time | localtime("MM/DD") }}</span
-                >
-                {{ rank[problem.id].ac_time | localtime("HH:mm:ss") }}
+                <div class="problem-status ac">
+                  <span class="problem-status-date">
+                    {{ rank[problem.id].ac_time | localtime("MM/DD") }}
+                  </span>
+                  <span class="problem-status-time">
+                    {{ rank[problem.id].ac_time | localtime("HH:mm:ss") }}
+                  </span>
+                </div>
+              </CustomTooltip>
+              <div
+                v-else-if="rank[problem.id].status"
+                class="problem-status"
+                :class="rank[problem.id].status"
+              >
+                <span class="problem-status-label">WA</span>
+                <span class="problem-status-time">
+                  {{ rank[problem.id].error_number || "-" }}
+                </span>
               </div>
             </td>
           </tr>
@@ -145,17 +148,28 @@ export default {
     addRankData(dataRank, problems) {
       problems.forEach((problem) => {
         dataRank.forEach((rank, idx) => {
-          dataRank[idx][problem.id] = { isSet: false, problemId: problem._id }
+          dataRank[idx][problem.id] = {
+            status: "",
+            error_number: 0,
+            problemId: problem._id,
+          }
         })
       })
       dataRank.forEach((rank, i) => {
         let info = rank.submission_info
         Object.keys(info).forEach((problemID) => {
           if (!dataRank[i][problemID]) return
-          dataRank[i][problemID].ac_time = moment(this.contest.start_time)
-            .add(info[problemID].ac_time, "seconds")
-            .format()
-          dataRank[i][problemID].isSet = true
+          dataRank[i][problemID].error_number = info[problemID].error_number || 0
+          if (info[problemID].is_ac) {
+            dataRank[i][problemID].ac_time = moment(this.contest.start_time)
+              .add(info[problemID].ac_time, "seconds")
+              .format()
+            dataRank[i][problemID].attempt_count =
+              dataRank[i][problemID].error_number + 1
+            dataRank[i][problemID].status = "ac"
+          } else {
+            dataRank[i][problemID].status = "wa"
+          }
         })
         dataRank[i].idx = (this.page - 1) * this.limit + i + 1
       })
@@ -215,5 +229,36 @@ export default {
   tr {
     font-size: 1.05em;
   }
+}
+
+.problem-status {
+  display: inline-flex;
+  min-width: 58px;
+  flex-direction: column;
+  align-items: center;
+  border-radius: 8px;
+  padding: 6px 8px;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.problem-status-date,
+.problem-status-label {
+  font-size: 11px;
+}
+
+.problem-status-time {
+  font-size: 12px;
+  margin-top: 2px;
+}
+
+.problem-status.ac {
+  background: #e8f7ee;
+  color: #1f8f52;
+}
+
+.problem-status.wa {
+  background: #fff1eb;
+  color: #c7512d;
 }
 </style>

--- a/frontend/src/pages/oj/views/contest/children/ACMContestRank.vue
+++ b/frontend/src/pages/oj/views/contest/children/ACMContestRank.vue
@@ -5,7 +5,7 @@
         <p>{{ $t("m.Rank") }}</p>
       </div>
       <div
-        v-if="!dataRank.length"
+        v-if="!loadingRank && !dataRank.length"
         style="text-align: center; font-size: 16px; padding-top: 50px"
       >
         {{ $t("m.No_Submissions") }}
@@ -35,7 +35,28 @@
             </CustomTooltip>
           </th>
         </thead>
-        <tbody>
+        <tbody v-if="loadingRank">
+          <tr
+            v-for="row in 5"
+            :key="`acm-rank-skeleton-${row}`"
+          >
+            <td><div class="rank-skeleton-box rank-skeleton-box-sm"><SkeletonBox /></div></td>
+            <td>
+              <div class="rank-skeleton-user">
+                <div class="rank-skeleton-avatar"><SkeletonBox /></div>
+                <div class="rank-skeleton-box rank-skeleton-box-md"><SkeletonBox /></div>
+              </div>
+            </td>
+            <td><div class="rank-skeleton-box rank-skeleton-box-sm"><SkeletonBox /></div></td>
+            <td
+              v-for="problem in skeletonProblemCount"
+              :key="`acm-rank-skeleton-problem-${row}-${problem}`"
+            >
+              <div class="rank-skeleton-box rank-skeleton-box-sm"><SkeletonBox /></div>
+            </td>
+          </tr>
+        </tbody>
+        <tbody v-else>
           <tr v-for="rank in dataRank">
             <td>{{ rank.idx }}</td>
             <td>
@@ -108,12 +129,14 @@ import ContestRankMixin from "./contestRankMixin"
 import time from "@/utils/time"
 import utils from "@/utils/utils"
 import CustomTooltip from "@oj/components/CustomTooltip"
+import SkeletonBox from "@oj/components/SkeletonBox"
 
 export default {
   name: "acm-contest-rank",
   components: {
     Pagination,
     CustomTooltip,
+    SkeletonBox,
   },
   mixins: [ContestRankMixin],
   data() {
@@ -122,7 +145,13 @@ export default {
       page: 1,
       contestID: "",
       dataRank: [],
+      loadingRank: false,
     }
+  },
+  computed: {
+    skeletonProblemCount() {
+      return this.contestProblems.length || 4
+    },
   },
   mounted() {
     this.contestID = this.$route.params.contestID
@@ -131,6 +160,7 @@ export default {
   methods: {
     ...mapActions(["getContestProblems"]),
     updateContestData() {
+      this.loadingRank = true
       let params = {
         offset: (this.page - 1) * this.limit,
         limit: this.limit,
@@ -143,8 +173,11 @@ export default {
 
         this.getContestProblems().then((res) => {
           this.addRankData(dataRank, res.data.data)
+          this.loadingRank = false
         })
         this.total = res.data.data.total
+      }).catch(() => {
+        this.loadingRank = false
       })
     },
     addRankData(dataRank, problems) {
@@ -269,5 +302,40 @@ export default {
   font-weight: 600;
   line-height: 1;
   color: #2f3c57;
+}
+
+.rank-skeleton-user {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  justify-content: center;
+}
+
+.rank-skeleton-avatar {
+  width: 36px;
+  height: 36px;
+  flex-shrink: 0;
+}
+
+.rank-skeleton-avatar /deep/ .skeleton {
+  border-radius: 50%;
+}
+
+.rank-skeleton-user-text {
+  width: 120px;
+  height: 18px;
+}
+
+.rank-skeleton-box {
+  height: 18px;
+  margin: 0 auto;
+}
+
+.rank-skeleton-box-sm {
+  width: 42px;
+}
+
+.rank-skeleton-box-md {
+  width: 120px;
 }
 </style>

--- a/frontend/src/pages/oj/views/contest/children/ACMContestRank.vue
+++ b/frontend/src/pages/oj/views/contest/children/ACMContestRank.vue
@@ -5,7 +5,13 @@
         <p>{{ $t("m.Rank") }}</p>
       </div>
       <div
-        v-if="!loadingRank && !dataRank.length"
+        v-if="!loadingRank && rankLoadError"
+        style="text-align: center; font-size: 16px; padding-top: 50px"
+      >
+        {{ $t("m.Unknown_Error") }}
+      </div>
+      <div
+        v-else-if="!loadingRank && !dataRank.length"
         style="text-align: center; font-size: 16px; padding-top: 50px"
       >
         {{ $t("m.No_Submissions") }}
@@ -17,7 +23,10 @@
           <th>
             {{ $t("m.Solved_Problems") }}
           </th>
-          <th v-for="problem in contestProblems">
+          <th
+            v-for="problem in contestProblems"
+            :key="`acm-rank-header-${problem.id}`"
+          >
             <CustomTooltip :content="problem.title" placement="top">
               <a
                 style="
@@ -57,7 +66,10 @@
           </tr>
         </tbody>
         <tbody v-else>
-          <tr v-for="rank in dataRank">
+          <tr
+            v-for="rank in dataRank"
+            :key="`acm-rank-row-${rank.id || rank.user.id}`"
+          >
             <td>{{ rank.idx }}</td>
             <td>
               <a
@@ -79,7 +91,10 @@
             <td>
               <span class="accepted-count-value">{{ rank.accepted_number }}</span>
             </td>
-            <td v-for="problem in contestProblems">
+            <td
+              v-for="problem in contestProblems"
+              :key="`acm-rank-problem-${rank.id || rank.user.id}-${problem.id}`"
+            >
               <CustomTooltip
                 v-if="rank[problem.id].status === 'ac'"
                 :content="`${rank[problem.id].attempt_count}회 시도`"
@@ -126,8 +141,6 @@ import { mapActions } from "vuex"
 import api from "@oj/api"
 import Pagination from "@oj/components/Pagination"
 import ContestRankMixin from "./contestRankMixin"
-import time from "@/utils/time"
-import utils from "@/utils/utils"
 import CustomTooltip from "@oj/components/CustomTooltip"
 import SkeletonBox from "@oj/components/SkeletonBox"
 
@@ -146,6 +159,7 @@ export default {
       contestID: "",
       dataRank: [],
       loadingRank: false,
+      rankLoadError: false,
     }
   },
   computed: {
@@ -161,6 +175,7 @@ export default {
     ...mapActions(["getContestProblems"]),
     updateContestData() {
       this.loadingRank = true
+      this.rankLoadError = false
       let params = {
         offset: (this.page - 1) * this.limit,
         limit: this.limit,
@@ -171,12 +186,15 @@ export default {
         const data = res.data.data.results
         let dataRank = JSON.parse(JSON.stringify(data))
 
-        this.getContestProblems().then((res) => {
-          this.addRankData(dataRank, res.data.data)
-          this.loadingRank = false
-        })
         this.total = res.data.data.total
+        return this.getContestProblems().then((problemRes) => {
+          this.addRankData(dataRank, problemRes.data.data)
+        })
       }).catch(() => {
+        this.dataRank = []
+        this.total = 0
+        this.rankLoadError = true
+      }).finally(() => {
         this.loadingRank = false
       })
     },

--- a/frontend/src/pages/oj/views/contest/children/ACMContestRank.vue
+++ b/frontend/src/pages/oj/views/contest/children/ACMContestRank.vue
@@ -293,8 +293,8 @@ export default {
 }
 
 .problem-status.wa {
-  background: #fff1eb;
-  color: #c7512d;
+  background: #f3f4f7;
+  color: #5b6472;
 }
 
 .accepted-count-value {

--- a/frontend/src/pages/oj/views/contest/children/ContestProblemList.vue
+++ b/frontend/src/pages/oj/views/contest/children/ContestProblemList.vue
@@ -24,7 +24,13 @@
       />
     </div>
     <div
-      v-if="problems.length === 0"
+      v-if="problemLoadError"
+      style="text-align: center; font-size: 16px"
+    >
+      {{ $t("m.Unknown_Error") }}
+    </div>
+    <div
+      v-else-if="problems.length === 0"
       style="text-align: center; font-size: 16px"
     >
       {{ $t("m.No_Problems") }}
@@ -113,6 +119,7 @@ export default {
       totalProblems: 0,
       limit: 10,
       page: 1,
+      problemLoadError: false,
     }
   },
   mounted() {
@@ -124,6 +131,7 @@ export default {
       this.getContestProblems()
     },
     getContestProblems() {
+      this.problemLoadError = false
       this.$store.dispatch("getContestProblems", this.keyword)
         .then((res) => {
           if (this.isAuthenticated) {
@@ -134,7 +142,10 @@ export default {
             }
           }
         })
-        .catch(() => {})
+        .catch((err) => {
+          this.problemLoadError = true
+          console.error("Failed to fetch contest problems:", err)
+        })
     },
     goContestProblem(id) {
       this.$router.push({

--- a/frontend/src/pages/oj/views/contest/children/ContestProblemList.vue
+++ b/frontend/src/pages/oj/views/contest/children/ContestProblemList.vue
@@ -208,6 +208,8 @@ export default {
 }
 .problemTable {
   text-align: center;
+  border-collapse: collapse;
+  border-spacing: 0;
   th {
     color: #7e7e7e;
     font-size: 1.3em;

--- a/frontend/src/pages/oj/views/contest/children/ContestProblemList.vue
+++ b/frontend/src/pages/oj/views/contest/children/ContestProblemList.vue
@@ -46,7 +46,11 @@
         <th>{{ $t("m.Th_Problem_Submission_State") }}</th>
       </thead>
       <tbody>
-        <tr v-for="problem in problems" @click="goContestProblem(problem._id)">
+        <tr
+          v-for="problem in problems"
+          :key="`contest-problem-row-${problem._id}`"
+          @click="goContestProblem(problem._id)"
+        >
           <td style="white-space: nowrap; text-align: left">
             {{ problem._id }}
           </td>
@@ -77,7 +81,11 @@
         <th>{{ $t("m.Th_Problem_Submission_State") }}</th>
       </thead>
       <tbody>
-        <tr v-for="problem in problems" @click="goContestProblem(problem._id)">
+        <tr
+          v-for="problem in problems"
+          :key="`contest-problem-row-compact-${problem._id}`"
+          @click="goContestProblem(problem._id)"
+        >
           <td>{{ problem._id }}</td>
           <td class="TableTitle">
             {{ problem.title }}
@@ -93,13 +101,11 @@
 import { mapState, mapGetters } from "vuex"
 import { ProblemMixin } from "@oj/components/mixins"
 import { DIFFICULTY_MAP, FIELD_MAP } from "../../../../../utils/constants"
-import FieldCategoryBox from "../../../components/FieldCategoryBox.vue"
 import CustomTooltip from "@oj/components/CustomTooltip"
-import Pagination from "@/pages/admin/components/Pagination"
 
 export default {
   name: "ContestProblemList",
-  components: { FieldCategoryBox, CustomTooltip, Pagination },
+  components: { CustomTooltip },
   mixins: [ProblemMixin],
   data() {
     return {
@@ -118,15 +124,17 @@ export default {
       this.getContestProblems()
     },
     getContestProblems() {
-      this.$store.dispatch("getContestProblems", this.keyword).then((res) => {
-        if (this.isAuthenticated) {
-          if (this.contestRuleType === "ACM") {
-            this.addStatusColumn(this.ACMTableColumns, res.data.data)
-          } else if (this.OIContestRealTimePermission) {
-            this.addStatusColumn(this.ACMTableColumns, res.data.data)
+      this.$store.dispatch("getContestProblems", this.keyword)
+        .then((res) => {
+          if (this.isAuthenticated) {
+            if (this.contestRuleType === "ACM") {
+              this.addStatusColumn(this.ACMTableColumns, res.data.data)
+            } else if (this.OIContestRealTimePermission) {
+              this.addStatusColumn(this.ACMTableColumns, res.data.data)
+            }
           }
-        }
-      })
+        })
+        .catch(() => {})
     },
     goContestProblem(id) {
       this.$router.push({

--- a/frontend/src/pages/oj/views/contest/children/OIContestRank.vue
+++ b/frontend/src/pages/oj/views/contest/children/OIContestRank.vue
@@ -5,7 +5,7 @@
         <p>{{ $t("m.Rank") }}</p>
       </div>
       <div
-        v-if="!myDataRank.length"
+        v-if="!loadingRank && !myDataRank.length"
         style="text-align: center; font-size: 16px; padding-top: 50px"
       >
         {{ $t("m.No_Submissions") }}
@@ -33,7 +33,28 @@
             </CustomTooltip>
           </th>
         </thead>
-        <tbody>
+        <tbody v-if="loadingRank">
+          <tr
+            v-for="row in 5"
+            :key="`oi-rank-skeleton-${row}`"
+          >
+            <td><div class="rank-skeleton-box rank-skeleton-box-sm"><SkeletonBox /></div></td>
+            <td>
+              <div class="rank-skeleton-user">
+                <div class="rank-skeleton-avatar"><SkeletonBox /></div>
+                <div class="rank-skeleton-box rank-skeleton-box-md"><SkeletonBox /></div>
+              </div>
+            </td>
+            <td><div class="rank-skeleton-box rank-skeleton-box-sm"><SkeletonBox /></div></td>
+            <td
+              v-for="problem in skeletonProblemCount"
+              :key="`oi-rank-skeleton-problem-${row}-${problem}`"
+            >
+              <div class="rank-skeleton-box rank-skeleton-box-sm"><SkeletonBox /></div>
+            </td>
+          </tr>
+        </tbody>
+        <tbody v-else>
           <tr v-for="rank in myDataRank">
             <td>{{ rank.idx }}</td>
             <td>
@@ -80,12 +101,14 @@ import Pagination from "@oj/components/Pagination"
 import ContestRankMixin from "./contestRankMixin"
 import utils from "@/utils/utils"
 import CustomTooltip from "@oj/components/CustomTooltip"
+import SkeletonBox from "@oj/components/SkeletonBox"
 
 export default {
   name: "acm-contest-rank",
   components: {
     Pagination,
     CustomTooltip,
+    SkeletonBox,
   },
   mixins: [ContestRankMixin],
   data() {
@@ -94,7 +117,13 @@ export default {
       page: 1,
       contestID: "",
       myDataRank: [],
+      loadingRank: false,
     }
+  },
+  computed: {
+    skeletonProblemCount() {
+      return this.contestProblems.length || 4
+    },
   },
   mounted() {
     this.contestID = this.$route.params.contestID
@@ -103,6 +132,7 @@ export default {
   methods: {
     ...mapActions(["getContestProblems"]),
     updateContestData() {
+      this.loadingRank = true
       let params = {
         offset: (this.page - 1) * this.limit,
         limit: this.limit,
@@ -115,8 +145,11 @@ export default {
 
         this.getContestProblems().then((res) => {
           this.addRankData(dataRank, res.data.data)
+          this.loadingRank = false
         })
         this.total = res.data.data.total
+      }).catch(() => {
+        this.loadingRank = false
       })
     },
     addRankData(dataRank, problems) {
@@ -191,5 +224,40 @@ export default {
   tr {
     font-size: 1.05em;
   }
+}
+
+.rank-skeleton-user {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  justify-content: center;
+}
+
+.rank-skeleton-avatar {
+  width: 36px;
+  height: 36px;
+  flex-shrink: 0;
+}
+
+.rank-skeleton-avatar /deep/ .skeleton {
+  border-radius: 50%;
+}
+
+.rank-skeleton-user-text {
+  width: 120px;
+  height: 18px;
+}
+
+.rank-skeleton-box {
+  height: 18px;
+  margin: 0 auto;
+}
+
+.rank-skeleton-box-sm {
+  width: 42px;
+}
+
+.rank-skeleton-box-md {
+  width: 120px;
 }
 </style>

--- a/frontend/src/pages/oj/views/contest/children/OIContestRank.vue
+++ b/frontend/src/pages/oj/views/contest/children/OIContestRank.vue
@@ -16,7 +16,7 @@
           <th>{{ $t("m.Contest_Participant") }}</th>
           <th>{{ $t("m.Total_Score") }}</th>
           <th v-for="problem in contestProblems">
-            <CustomTooltip :content="problem._id" placement="top">
+            <CustomTooltip :content="problem.title" placement="top">
               <a
                 style="
                   color: #6ccbff;

--- a/frontend/src/pages/oj/views/contest/children/OIContestRank.vue
+++ b/frontend/src/pages/oj/views/contest/children/OIContestRank.vue
@@ -74,9 +74,14 @@
                 {{ rank.user.username }}
               </a>
             </td>
-            <td>{{ rank.total_score }}</td>
+            <td>
+              <span class="total-score-value">{{ rank.total_score }}</span>
+            </td>
             <td v-for="problem in contestProblems">
-              <div v-if="rank[problem.id].isSet">
+              <div
+                v-if="rank[problem.id] && rank[problem.id].isSet"
+                class="problem-score"
+              >
                 {{ rank[problem.id].total_score }}
               </div>
             </td>
@@ -143,10 +148,13 @@ export default {
         const data = res.data.data.results
         let dataRank = JSON.parse(JSON.stringify(data))
 
-        this.getContestProblems().then((res) => {
-          this.addRankData(dataRank, res.data.data)
-          this.loadingRank = false
-        })
+        this.getContestProblems()
+          .then((res) => {
+            this.addRankData(dataRank, res.data.data)
+          })
+          .finally(() => {
+            this.loadingRank = false
+          })
         this.total = res.data.data.total
       }).catch(() => {
         this.loadingRank = false
@@ -161,6 +169,7 @@ export default {
       dataRank.forEach((rank, i) => {
         let info = rank.submission_info
         Object.keys(info).forEach((problemID) => {
+          if (!dataRank[i][problemID]) return
           dataRank[i][problemID].total_score = info[problemID]
           dataRank[i][problemID].isSet = true
         })
@@ -207,6 +216,8 @@ export default {
 .OIRankContent {
   text-align: center;
   display: block;
+  border-collapse: collapse;
+  border-spacing: 0;
   padding-top: 50px;
   max-width: 928px;
   overflow-y: visible;
@@ -219,11 +230,31 @@ export default {
   }
   td {
     border-top: 1px solid rgba(0, 0, 0, 0.1);
-    padding: 10px 0px;
+    padding: 6px 8px;
   }
   tr {
     font-size: 1.05em;
   }
+}
+
+.problem-score {
+  display: inline-flex;
+  min-width: 54px;
+  justify-content: center;
+  align-items: center;
+  border-radius: 8px;
+  padding: 12px 8px;
+  background: #f5f7fb;
+  color: #495060;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.total-score-value {
+  font-size: 20px;
+  font-weight: 600;
+  line-height: 1;
+  color: #2f3c57;
 }
 
 .rank-skeleton-user {

--- a/frontend/src/pages/oj/views/contest/children/OIContestRank.vue
+++ b/frontend/src/pages/oj/views/contest/children/OIContestRank.vue
@@ -5,7 +5,13 @@
         <p>{{ $t("m.Rank") }}</p>
       </div>
       <div
-        v-if="!loadingRank && !myDataRank.length"
+        v-if="!loadingRank && rankLoadError"
+        style="text-align: center; font-size: 16px; padding-top: 50px"
+      >
+        {{ $t("m.Unknown_Error") }}
+      </div>
+      <div
+        v-else-if="!loadingRank && !myDataRank.length"
         style="text-align: center; font-size: 16px; padding-top: 50px"
       >
         {{ $t("m.No_Submissions") }}
@@ -15,7 +21,10 @@
           <th style="width: 50px">{{ $t("m.Contest_Rank") }}</th>
           <th>{{ $t("m.Contest_Participant") }}</th>
           <th>{{ $t("m.Total_Score") }}</th>
-          <th v-for="problem in contestProblems">
+          <th
+            v-for="problem in contestProblems"
+            :key="`oi-rank-header-${problem.id}`"
+          >
             <CustomTooltip :content="problem.title" placement="top">
               <a
                 style="
@@ -55,7 +64,10 @@
           </tr>
         </tbody>
         <tbody v-else>
-          <tr v-for="rank in myDataRank">
+          <tr
+            v-for="rank in myDataRank"
+            :key="`oi-rank-row-${rank.id || rank.user.id}`"
+          >
             <td>{{ rank.idx }}</td>
             <td>
               <a
@@ -77,7 +89,10 @@
             <td>
               <span class="total-score-value">{{ rank.total_score }}</span>
             </td>
-            <td v-for="problem in contestProblems">
+            <td
+              v-for="problem in contestProblems"
+              :key="`oi-rank-problem-${rank.id || rank.user.id}-${problem.id}`"
+            >
               <div
                 v-if="rank[problem.id] && rank[problem.id].isSet"
                 class="problem-score"
@@ -104,12 +119,11 @@ import { mapActions } from "vuex"
 import api from "@oj/api"
 import Pagination from "@oj/components/Pagination"
 import ContestRankMixin from "./contestRankMixin"
-import utils from "@/utils/utils"
 import CustomTooltip from "@oj/components/CustomTooltip"
 import SkeletonBox from "@oj/components/SkeletonBox"
 
 export default {
-  name: "acm-contest-rank",
+  name: "oi-contest-rank",
   components: {
     Pagination,
     CustomTooltip,
@@ -123,6 +137,7 @@ export default {
       contestID: "",
       myDataRank: [],
       loadingRank: false,
+      rankLoadError: false,
     }
   },
   computed: {
@@ -138,6 +153,7 @@ export default {
     ...mapActions(["getContestProblems"]),
     updateContestData() {
       this.loadingRank = true
+      this.rankLoadError = false
       let params = {
         offset: (this.page - 1) * this.limit,
         limit: this.limit,
@@ -148,15 +164,16 @@ export default {
         const data = res.data.data.results
         let dataRank = JSON.parse(JSON.stringify(data))
 
-        this.getContestProblems()
+        this.total = res.data.data.total
+        return this.getContestProblems()
           .then((res) => {
             this.addRankData(dataRank, res.data.data)
           })
-          .finally(() => {
-            this.loadingRank = false
-          })
-        this.total = res.data.data.total
       }).catch(() => {
+        this.myDataRank = []
+        this.total = 0
+        this.rankLoadError = true
+      }).finally(() => {
         this.loadingRank = false
       })
     },

--- a/frontend/src/store/modules/contest.js
+++ b/frontend/src/store/modules/contest.js
@@ -56,7 +56,7 @@ const getters = {
     }
     return !state.access
   },
-  OIContestRealTimePermission: (state, getters, _, rootGetters) => {
+  OIContestRealTimePermission: (state, getters) => {
     if (
       getters.contestRuleType === "ACM" ||
       getters.contestStatus === CONTEST_STATUS.ENDED
@@ -213,14 +213,15 @@ const actions = {
           })
           resolve(res)
         },
-        () => {
+        (err) => {
           commit(types.CHANGE_CONTEST_PROBLEMS, { contestProblems: [] })
+          reject(err)
         },
       )
     })
   },
   getContestAccess({ commit, rootState }) {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       api
         .getContestAccess(rootState.route.params.contestID)
         .then((res) => {


### PR DESCRIPTION
Close #597 
# Changelog

<!-- 이 PR에서 변경된 내용을 자세하게 기술해주세요. -->
<!-- 추가/수정/삭제된 기능이나 버그 수정 사항을 명확히 작성해주세요. -->

### 1. 닉네임을 변경한 사용자가 대회 참가자 목록에 중복 표시되던 문제를 수정했습니다.
  - 참가자 집계 기준을 `user_id`로 변경
  - 참가자 목록 API 테스트를 추가했습니다.
  - 기존
  <img width="1544" height="424" alt="image" src="https://github.com/user-attachments/assets/5c440177-a1f9-4cb4-be44-9e0cb674e58e" />


  - 적용 후
  <img width="1541" height="356" alt="image" src="https://github.com/user-attachments/assets/9be0ded2-1404-426b-8a6f-d4858e15a468" />

### 2. 대회 랭킹 페이지에서 문제 툴팁이 문제 번호 대신 문제 제목을 표시하도록 수정했습니다.
  - 기존
  <img width="364" height="167" alt="image" src="https://github.com/user-attachments/assets/4175014e-3b7d-4d1c-b5c7-4b491a5f6ff3" />

  - 적용 후
  <img width="412" height="165" alt="image" src="https://github.com/user-attachments/assets/6123d625-072f-45a5-9add-a20f4d869615" />


### 3. 대회 랭킹 페이지에서 로딩 중 '제출 현황이 없습니다' 문구가 먼저 노출되지 않도록 스켈레톤 로딩을 적용하였습니다.

<img width="1351" height="628" alt="image" src="https://github.com/user-attachments/assets/76752a66-2018-4b64-9509-38ffc7c50f50" />

### 4. #597 대회 랭킹에서 오답 제출(WA/CE)과 정답 제출(AC)을 구분할 수 없던 문제를 해결했습니다.
 - ACM/OI 랭킹에서 제출 상태 표시를 개선했습니다.
  - 정답 제출은 시간 정보와 시도 횟수를 툴팁으로 표시
  - 오답 제출은 WA 상태와 횟수를 별도 배지로 표시
  -  기존 ACM
  <img width="1786" height="971" alt="image" src="https://github.com/user-attachments/assets/4e6e4dd0-9c81-48e2-af0d-1142e0ba332c" />

  - 적용 후 ACM
  <img width="1800" height="978" alt="image" src="https://github.com/user-attachments/assets/6bf9b656-94a6-4516-bf9e-85f6910699e9" />


  - 기존 OI
  <img width="614" height="246" alt="image" src="https://github.com/user-attachments/assets/b2d13333-f608-4b4f-a428-ef3411215ef3" />

  - 적용 후 OI / OI 디자인은 맘에 들지 않으나 거의 사용 안하므로 일단 보류..
  <img width="364" height="215" alt="image" src="https://github.com/user-attachments/assets/9ffac98a-8ff0-42d3-b51e-df12f9b7ad95" />





# Testing

<!-- 테스트 방법과 결과를 상세히 기술해주세요. -->
<!-- 단위 테스트, 통합 테스트 결과나 수동 테스트 내용을 포함해주세요. -->
<!-- 스크린샷이나 로그도 첨부하면 좋습니다. -->
  - `cd backend && ./venv/bin/python manage.py test contest.tests.ContestParticipantsAPITest`
  - 결과: `OK`
  - 프론트 작업은 수동 테스트 완료


# Ops Impact

<!-- 이 변경사항이 운영에 미치는 영향을 설명해주세요. -->
<!-- 서버 재시작이 필요한지, DB 마이그레이션이 있는지, 성능에 영향을 주는지 등 운영팀이 알아야 할 사항을 기재해주세요. -->
<!-- 해당 사항이 없다면 N/A로 기재해주세요. -->
N/A

# Version Compatibility

<!-- 이 변경사항이 기존 버전과의 호환성에 영향을 주는지 설명해주세요. -->
<!-- 하위/상위 버전 호환성 이슈가 있는지, 클라이언트/서버 버전 동기화가 필요한지 등을 기재해주세요. -->
<!-- 해당 사항이 없다면 N/A로 기재해주세요. -->
N/A