### PR TITLE
fix: 대회 내 AI조교 기본값 off로 설정

### DIFF
--- a/backend/contest/models.py
+++ b/backend/contest/models.py
@@ -26,7 +26,7 @@ class Contest(models.Model):
     visible = models.BooleanField(default=True)
     allowed_ip_ranges = JSONField(default=list)
     #AI assistant
-    ai_assistant_enabled = models.BooleanField(default=True)
+    ai_assistant_enabled = models.BooleanField(default=False)
 
     @property
     def status(self):

--- a/backend/contest/serializers.py
+++ b/backend/contest/serializers.py
@@ -28,7 +28,7 @@ class CreateConetestSeriaizer(serializers.Serializer):
     real_time_rank = serializers.BooleanField()
     allow_paste = serializers.BooleanField()
     allowed_ip_ranges = serializers.ListField(child=serializers.CharField(max_length=32), allow_empty=True)
-    ai_assistant_enabled = serializers.BooleanField(default=True)
+    ai_assistant_enabled = serializers.BooleanField(default=False)
 
 
 class EditConetestSeriaizer(serializers.Serializer):

--- a/frontend/src/pages/admin/views/contest/Contest.vue
+++ b/frontend/src/pages/admin/views/contest/Contest.vue
@@ -241,7 +241,7 @@ export default {
         real_time_rank: true,
         visible: true,
         allow_paste: true,
-        ai_assistant_enabled: true,
+        ai_assistant_enabled: false,
         allowed_ip_ranges: [{ value: "" }],
       },
     }


### PR DESCRIPTION
# Changelog

- 대회 생성 시 AI 조교 활성화 여부의 기본값을 true → false로 변경
    - backend/contest/models.py: BooleanField(default=False)
    - backend/contest/serializers.py: BooleanField(default=False)
    - frontend/src/pages/admin/views/contest/Contest.vue: 초기 데이터 false로 변경
  - 기존에 생성된 대회(AI 조교 컬럼 추가 마이그레이션으로 true가 일괄 설정된 대회)는 별도 데이터 마이그레이션으로 false 처리 필요


# Testing



# Ops Impact

  - DB 마이그레이션 필요: 기존 대회의 ai_assistant_enabled를 false로 일괄 업데이트하는 데이터 마이그레이션 실행 필요

# Version Compatibility

N/A