### PR TITLE
#635 교육원 공지사항 제목 } 표시 제거

### DIFF
--- a/backend/contents/views/oj.py
+++ b/backend/contents/views/oj.py
@@ -72,7 +72,7 @@ class GetHomeRSSNoticeAPI(APIView):
                 if link and not link.startswith('http'):
                     link = BASE_URL + link
                 item_dict = {
-                    'title': item.find('title').text,
+                    'title': item.find('title').text.rstrip("}"),
                     'link': link,
                     'pubDate': item.find('pubDate').text
                 }


### PR DESCRIPTION
# Changelog
기본적으로 교육원 공지사항을 불러올 때 }이 포함되어있었고 이를 제거하지 않고 그대로 출력하여 문제 발생 -> .rstrip("}")로 }표시 제거
<!-- 이 PR에서 변경된 내용을 자세하게 기술해주세요. -->
<!-- 추가/수정/삭제된 기능이나 버그 수정 사항을 명확히 작성해주세요. -->

# Testing
<img width="1554" height="532" alt="image" src="https://github.com/user-attachments/assets/8327fd71-f2aa-4016-a56c-0067f7518f30" />

<!-- 테스트 방법과 결과를 상세히 기술해주세요. -->
<!-- 단위 테스트, 통합 테스트 결과나 수동 테스트 내용을 포함해주세요. -->
<!-- 스크린샷이나 로그도 첨부하면 좋습니다. -->

# Ops Impact
N/A
<!-- 이 변경사항이 운영에 미치는 영향을 설명해주세요. -->
<!-- 서버 재시작이 필요한지, DB 마이그레이션이 있는지, 성능에 영향을 주는지 등 운영팀이 알아야 할 사항을 기재해주세요. -->
<!-- 해당 사항이 없다면 N/A로 기재해주세요. -->

# Version Compatibility
N/A
<!-- 이 변경사항이 기존 버전과의 호환성에 영향을 주는지 설명해주세요. -->
<!-- 하위/상위 버전 호환성 이슈가 있는지, 클라이언트/서버 버전 동기화가 필요한지 등을 기재해주세요. -->
<!-- 해당 사항이 없다면 N/A로 기재해주세요. -->
