### PR TITLE
#601 test: AI 조교 기본값(off) 및 레거시 대회 동작 테스트 추가

### DIFF
--- a/backend/contest/tests.py
+++ b/backend/contest/tests.py
@@ -70,6 +70,75 @@ class ContestAdminAPITest(APITestCase):
         response = self.client.get("{}?id={}".format(self.url, id))
         self.assertSuccess(response)
 
+    def test_create_contest_without_ai_field_defaults_to_false(self):
+        """ai_assistant_enabled 필드 없이 대회를 생성하면 기본값이 False여야 한다."""
+        # DEFAULT_CONTEST_DATA에 ai_assistant_enabled 없음 → 레거시 클라이언트 재현
+        resp = self.client.post(self.url, data=DEFAULT_CONTEST_DATA)
+        self.assertSuccess(resp)
+
+        contest_id = resp.data["data"]["id"]
+        contest = Contest.objects.get(id=contest_id)
+        self.assertFalse(contest.ai_assistant_enabled)
+
+    def test_create_contest_with_ai_enabled_explicit(self):
+        """ai_assistant_enabled=True를 명시적으로 전달하면 True로 저장된다."""
+        data = copy.deepcopy(DEFAULT_CONTEST_DATA)
+        data["ai_assistant_enabled"] = True
+        resp = self.client.post(self.url, data=data)
+        self.assertSuccess(resp)
+
+        contest_id = resp.data["data"]["id"]
+        contest = Contest.objects.get(id=contest_id)
+        self.assertTrue(contest.ai_assistant_enabled)
+
+
+class ContestAIAssistantMigrationTest(APITestCase):
+    """데이터 마이그레이션: 기존 대회 ai_assistant_enabled 일괄 False 전환 검증."""
+
+    def setUp(self):
+        self.create_school_fixtures(college_id=1, college_name="Test", department_id=1, department_name="Test")
+        self.admin = self.create_admin()
+
+    def _bulk_disable(self):
+        """0004 마이그레이션의 disable_ai_assistant 함수와 동일한 로직."""
+        Contest.objects.filter(ai_assistant_enabled=True).update(ai_assistant_enabled=False)
+
+    def test_all_enabled_contests_become_disabled(self):
+        """ai_assistant_enabled=True인 대회가 모두 False로 전환된다."""
+        c1 = Contest.objects.create(created_by=self.admin, **DEFAULT_CONTEST_DATA)
+        c2 = Contest.objects.create(created_by=self.admin, **{**DEFAULT_CONTEST_DATA, "title": "second"})
+        Contest.objects.filter(pk__in=[c1.pk, c2.pk]).update(ai_assistant_enabled=True)
+
+        self._bulk_disable()
+
+        c1.refresh_from_db()
+        c2.refresh_from_db()
+        self.assertFalse(c1.ai_assistant_enabled)
+        self.assertFalse(c2.ai_assistant_enabled)
+
+    def test_already_disabled_contests_remain_disabled(self):
+        """이미 ai_assistant_enabled=False인 대회는 마이그레이션 후에도 False를 유지한다."""
+        contest = Contest.objects.create(created_by=self.admin, **DEFAULT_CONTEST_DATA)
+        self.assertFalse(contest.ai_assistant_enabled)
+
+        self._bulk_disable()
+
+        contest.refresh_from_db()
+        self.assertFalse(contest.ai_assistant_enabled)
+
+    def test_migration_does_not_affect_other_fields(self):
+        """마이그레이션이 ai_assistant_enabled 외의 필드를 변경하지 않는다."""
+        contest = Contest.objects.create(created_by=self.admin, **DEFAULT_CONTEST_DATA)
+        Contest.objects.filter(pk=contest.pk).update(ai_assistant_enabled=True)
+
+        self._bulk_disable()
+
+        contest.refresh_from_db()
+        self.assertFalse(contest.ai_assistant_enabled)
+        self.assertEqual(contest.title, DEFAULT_CONTEST_DATA["title"])
+        self.assertTrue(contest.visible)
+        self.assertTrue(contest.real_time_rank)
+
 
 class ContestAPITest(APITestCase):
 

--- a/backend/problem/tests.py
+++ b/backend/problem/tests.py
@@ -599,6 +599,63 @@ class ProblemLLMHintAPITest(ProblemCreateTestBase):
         with mock.patch.dict(os.environ, {"KUBERNETES_SERVICE_HOST": "10.0.0.1"}, clear=False):
             self.assertEqual(get_vllm_chat_completions_url(), CLUSTER_VLLM_CHAT_COMPLETIONS_URL)
 
+    # ------------------------------------------------------------------
+    # 레거시 대회 (ai_assistant_enabled 필드 도입 이전 생성) 테스트
+    # ------------------------------------------------------------------
+
+    def _make_public_contest_no_ai(self, problem_id):
+        """비밀번호 없는 공개 대회(ai_assistant_enabled=False)와 문제를 반환한다."""
+        contest = Contest.objects.create(
+            created_by=self.admin,
+            title="legacy contest",
+            description="desc",
+            start_time=timezone.localtime(timezone.now()) - timedelta(hours=1),
+            end_time=timezone.localtime(timezone.now()) + timedelta(days=1),
+            rule_type=ContestRuleType.ACM,
+            password="",
+            allowed_ip_ranges=[],
+            visible=True,
+            real_time_rank=True,
+            allow_paste=True,
+            # ai_assistant_enabled 생략 → 모델 기본값(False) 적용
+        )
+        problem = self.create_problem_with_custom_field(self.admin, _id=problem_id)
+        problem.contest = contest
+        problem.save(update_fields=["contest"])
+        return contest, problem
+
+    def test_legacy_contest_no_ai_field_blocks_hint(self):
+        """ai_assistant_enabled 없이 생성된 레거시 대회는 모델 기본값(False)이 적용되어 AI 힌트가 차단된다."""
+        contest, problem = self._make_public_contest_no_ai("L-001")
+
+        self.assertFalse(contest.ai_assistant_enabled)
+
+        resp = self.client.get(f"{self.url}?problem_id={problem._id}&contest_id={contest.id}")
+        body = self._streaming_body(resp)
+
+        self.assertIn("event: app-error", body)
+        self.assertIn("AI 조교를 사용할 수 없습니다", body)
+
+    def test_legacy_contest_after_bulk_disable_blocks_hint(self):
+        """데이터 마이그레이션으로 ai_assistant_enabled=True → False로 일괄 전환된 대회도 AI 힌트가 차단된다."""
+        contest, problem = self._make_public_contest_no_ai("L-002")
+
+        # 마이그레이션 전 상태 재현: 구 기본값(True)으로 강제 설정
+        Contest.objects.filter(pk=contest.pk).update(ai_assistant_enabled=True)
+        contest.refresh_from_db()
+        self.assertTrue(contest.ai_assistant_enabled)
+
+        # 데이터 마이그레이션 로직 실행 (ai_assistant_enabled=True인 대회를 전부 False로)
+        Contest.objects.filter(ai_assistant_enabled=True).update(ai_assistant_enabled=False)
+        contest.refresh_from_db()
+        self.assertFalse(contest.ai_assistant_enabled)
+
+        resp = self.client.get(f"{self.url}?problem_id={problem._id}&contest_id={contest.id}")
+        body = self._streaming_body(resp)
+
+        self.assertIn("event: app-error", body)
+        self.assertIn("AI 조교를 사용할 수 없습니다", body)
+
 
 class AIHintHistoryAPITest(ProblemCreateTestBase):
 


### PR DESCRIPTION
# Changelog

  테스트 코드 추가
  - problem/tests.py: 레거시 대회 AI 조교 차단 테스트 2개 추가
  - contest/tests.py: AI 조교 기본값 및 마이그레이션 테스트 5개 추가

# Testing

| 테스트 | 결과 |
|---|---|
| `test_legacy_contest_no_ai_field_blocks_hint` | PASS |
| `test_legacy_contest_after_bulk_disable_blocks_hint` | PASS |
| `test_create_contest_without_ai_field_defaults_to_false` | PASS |
| `test_create_contest_with_ai_enabled_explicit` | PASS |
| `test_all_enabled_contests_become_disabled` | PASS |
| `test_already_disabled_contests_remain_disabled` | PASS |
| `test_migration_does_not_affect_other_fields` | PASS |
# Ops Impact

DB migration 필요 

# Version Compatibility

  N/A
