### PR TITLE
#648 다크모드 색상 개선 및 코드 에디터 테마 통일

### DIFF
--- a/frontend/src/pages/oj/App.vue
+++ b/frontend/src/pages/oj/App.vue
@@ -167,15 +167,15 @@ h1.main-title {
 
 :root.dark.problem {
   /* Problem Solving Page */
-  --ps-background-color: #181c25;
+  --ps-background-color: #263238;
   /* Problem Solving Page - Inner Content */
-  --ps-content-color: #1f2430;
-  --ps-content-text-color: #b2c0cc;
+  --ps-content-color: #2e3c43;
+  --ps-content-text-color: #ececec;
   --ps-content-title-color: #ffffff;
-  --ps-content-pre-background-color: #1a1f29;
-  --ps-content-pre-border-color: rgba(140, 140, 140, 0.29);
-  --ps-content-code-background-color: #1b212c;
-  --ps-content-code-text-color: #ffffff;
+  --ps-content-pre-background-color: #233038;
+  --ps-content-pre-border-color: rgba(160, 160, 160, 0.2);
+  --ps-content-code-background-color: #1e2a30;
+  --ps-content-code-text-color: #ececec;
   /* Code Submission */
   --submit-btn-color: #343f5a;
   --submit-btn-hover-color: #364361;
@@ -213,7 +213,7 @@ h1.main-title {
   --ai-assistant-close-hover-text-color: #ffffff;
   --ai-assistant-error-text-color: #ff9e9e;
 
-  --bg-color: #1f2430;
+  --bg-color: #263238;
   --text-color: #ffffff;
   --difficulty-color: #5a6885;
   --custom-btn-hover-color: #465477;

--- a/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/CodeEditor.vue
+++ b/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/CodeEditor.vue
@@ -210,6 +210,16 @@ export default {
   border: 1px solid var(--border-color);
 }
 
+.cm-s-ayu-mirage.CodeMirror,
+.cm-s-ayu-mirage .CodeMirror-scroll {
+  background-color: #2e3c43 !important;
+}
+
+.cm-s-ayu-mirage .CodeMirror-gutters {
+  background-color: #263238 !important;
+  border-right: 1px solid rgba(160, 160, 160, 0.15) !important;
+}
+
 .cm-s-ayu-mirage .CodeMirror-matchingbracket {
   text-decoration: none !important;
   color: white !important;

--- a/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/ProblemDetailFlexibleContainer.vue
+++ b/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/ProblemDetailFlexibleContainer.vue
@@ -421,7 +421,7 @@ export default defineComponent({
       font-weight: 400;
       line-height: 1.6;
       letter-spacing: 0.01em;
-      color: #111111 !important;
+      color: var(--ps-content-text-color) !important;
     }
 
     .sample {


### PR DESCRIPTION
# Changelog
기존 다크모드가 너무 어둡고 일부 텍스트가 검은색으로
표시되는 문제가 있었습니다.

- 다크모드 배경색을 프로그래머스와 유사한 톤(#263238)으로 변경
- 문제 본문 텍스트 색상이 하드코딩(#111111)되어 다크모드에서도 검게 보이던 문제를 CSS 변수(--ps-content-text-color)로 수정
- 코드 에디터(ayu-mirage 테마) 배경색을 좌측 패널과 통일하여 전체적으로 일관된 다크모드 UI 제공
<!-- 이 PR에서 변경된 내용을 자세하게 기술해주세요. -->
<!-- 추가/수정/삭제된 기능이나 버그 수정 사항을 명확히 작성해주세요. -->

# Testing
<img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/2f9ac7b5-c929-4599-b4a0-7366f4faab6a" />

<!-- 테스트 방법과 결과를 상세히 기술해주세요. -->
<!-- 단위 테스트, 통합 테스트 결과나 수동 테스트 내용을 포함해주세요. -->
<!-- 스크린샷이나 로그도 첨부하면 좋습니다. -->

# Ops Impact
N/A
<!-- 이 변경사항이 운영에 미치는 영향을 설명해주세요. -->
<!-- 서버 재시작이 필요한지, DB 마이그레이션이 있는지, 성능에 영향을 주는지 등 운영팀이 알아야 할 사항을 기재해주세요. -->
<!-- 해당 사항이 없다면 N/A로 기재해주세요. -->

# Version Compatibility
N/A
<!-- 이 변경사항이 기존 버전과의 호환성에 영향을 주는지 설명해주세요. -->
<!-- 하위/상위 버전 호환성 이슈가 있는지, 클라이언트/서버 버전 동기화가 필요한지 등을 기재해주세요. -->
<!-- 해당 사항이 없다면 N/A로 기재해주세요. -->
