### PR TITLE
#646 언어 선택 드롭다운 위에 툴팁 겹침 현상 수정 revert됨

### DIFF
--- a/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/CodeEditorHeader.vue
+++ b/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/CodeEditorHeader.vue
@@ -12,7 +12,7 @@
         gap: 10px;
       "
     >
-      <Tooltip :content="'언어 선택'" placement="top">
+      <Tooltip :content="'언어 선택'" placement="top" :transfer="true">
         <Dropdown @on-click="changeLanguage" trigger="click" class="dropdown">
           <span
             style="font-size: 13px; padding-right: 3px; font-weight: 450"

--- a/frontend/src/styles/iview-custom.less
+++ b/frontend/src/styles/iview-custom.less
@@ -1,6 +1,9 @@
 table {
   width: 100% !important;
 }
+.ivu-select-dropdown {
+  z-index: 1100 !important;
+}
 .auto-resize {
   table {
     table-layout: auto !important;


### PR DESCRIPTION
# Changelog
NavBar의 z-index(1000)보다 iView 툴팁의 z-index가 낮아
언어 선택 드롭다운 메뉴를 열었을 때 "언어 선택" 툴팁이
드롭다운 메뉴 위에 겹쳐 보이는 문제가 있었습니다.

Tooltip에 transfer 옵션을 추가하여 툴팁을 body에 직접
렌더링하도록 변경하고, iView 드롭다운 메뉴의 z-index를
1100으로 올려 navbar보다 항상 위에 표시되도록 수정했습니다.
<!-- 이 PR에서 변경된 내용을 자세하게 기술해주세요. -->
<!-- 추가/수정/삭제된 기능이나 버그 수정 사항을 명확히 작성해주세요. -->

# Testing
<img width="976" height="664" alt="image" src="https://github.com/user-attachments/assets/d5d64982-e30e-4021-90b6-50787a1ec483" />

<!-- 테스트 방법과 결과를 상세히 기술해주세요. -->
<!-- 단위 테스트, 통합 테스트 결과나 수동 테스트 내용을 포함해주세요. -->
<!-- 스크린샷이나 로그도 첨부하면 좋습니다. -->

# Ops Impact
N/A
<!-- 이 변경사항이 운영에 미치는 영향을 설명해주세요. -->
<!-- 서버 재시작이 필요한지, DB 마이그레이션이 있는지, 성능에 영향을 주는지 등 운영팀이 알아야 할 사항을 기재해주세요. -->
<!-- 해당 사항이 없다면 N/A로 기재해주세요. -->

# Version Compatibility
N/A
<!-- 이 변경사항이 기존 버전과의 호환성에 영향을 주는지 설명해주세요. -->
<!-- 하위/상위 버전 호환성 이슈가 있는지, 클라이언트/서버 버전 동기화가 필요한지 등을 기재해주세요. -->
<!-- 해당 사항이 없다면 N/A로 기재해주세요. -->
