### PR TITLE
이미지가 한줄 전체 차지하는 현상 수정(hotfix-dev)

### DIFF
--- a/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/ProblemDetailFlexibleContainer.vue
+++ b/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/ProblemDetailFlexibleContainer.vue
@@ -434,11 +434,11 @@ export default defineComponent({
     }
 
     /deep/ img {
-      display: block;
+      display: inline-block;
       width: auto;
       max-width: ~"min(100%, 640px)";
       height: auto;
-      margin: 12px auto;
+      vertical-align: middle;
     }
 
     /deep/ .content img {


### PR DESCRIPTION
# Changelog

<!-- 이 PR에서 변경된 내용을 자세하게 기술해주세요. -->
<!-- 추가/수정/삭제된 기능이나 버그 수정 사항을 명확히 작성해주세요. -->
- 이미지가 한줄 전체 차지해 문제 내용 깨지는 현상 수정

#### 기존
<img width="789" height="359" alt="image" src="https://github.com/user-attachments/assets/fd970fa0-bfcd-4c4a-a231-3009eb07b74d" />

#### 수정 후
<img width="815" height="133" alt="image" src="https://github.com/user-attachments/assets/2df64d41-55b3-4c70-b244-120a2fe6c1bf" />
