### PR TITLE
#671 backend health probes 추가

### DIFF
--- a/backend/conf/tests.py
+++ b/backend/conf/tests.py
@@ -103,6 +103,14 @@ class WebsiteConfigAPITest(APITestCase):
         self.assertSuccess(resp)
 
 
+class HealthCheckAPITest(APITestCase):
+
+    def test_health_check_without_auth(self):
+        resp = self.client.get(self.reverse("health_check_api"))
+        self.assertEqual(resp.status_code, 204)
+        self.assertEqual(resp.content, b"")
+
+
 class JudgeServerHeartbeatTest(APITestCase):
 
     def setUp(self):

--- a/backend/conf/urls/oj.py
+++ b/backend/conf/urls/oj.py
@@ -1,8 +1,9 @@
 from django.conf.urls import url
 
-from ..views import JudgeServerHeartbeatAPI, LanguagesAPI, WebsiteConfigAPI
+from ..views import HealthCheckAPI, JudgeServerHeartbeatAPI, LanguagesAPI, WebsiteConfigAPI
 
 urlpatterns = [
+    url(r"^health/?$", HealthCheckAPI.as_view(), name="health_check_api"),
     url(r"^website/?$", WebsiteConfigAPI.as_view(), name="website_info_api"),
     url(r"^judge_server_heartbeat/?$", JudgeServerHeartbeatAPI.as_view(), name="judge_server_heartbeat_api"),
     url(r"^languages/?$", LanguagesAPI.as_view(), name="language_list_api")

--- a/backend/conf/views.py
+++ b/backend/conf/views.py
@@ -10,7 +10,9 @@ from datetime import datetime
 import pytz
 import requests
 from django.conf import settings
+from django.http import HttpResponse
 from django.utils import timezone
+from django.views.generic import View
 from requests.exceptions import RequestException
 
 from account.decorators import super_admin_required
@@ -87,6 +89,12 @@ class SMTPTestAPI(APIView):
             msg = str(e)
             return self.error(msg)
         return self.success()
+
+
+class HealthCheckAPI(View):
+
+    def get(self, request):
+        return HttpResponse(status=204)
 
 
 class WebsiteConfigAPI(APIView):

--- a/backend/deploy/health_check.py
+++ b/backend/deploy/health_check.py
@@ -1,4 +1,5 @@
 import xmlrpc.client
+import traceback
 
 if __name__ == "__main__":
     try:
@@ -6,6 +7,6 @@ if __name__ == "__main__":
             info = server.supervisor.getAllProcessInfo()
             error_states = list(filter(lambda x: x["state"] != 20, info))
             exit(len(error_states))
-    except Exception as e:
-        print(e.with_traceback())
+    except Exception:
+        traceback.print_exc()
         exit(1)

--- a/kubernetes/base/backend/deployment.yaml
+++ b/kubernetes/base/backend/deployment.yaml
@@ -86,6 +86,14 @@ spec:
                   name: common-credentials
                   key: AWS_SECRET_ACCESS_KEY
           # TODO: Security Context 설정을 추가해야 합니다. 현재 entrypoint.sh 에서 권한을 변경하고 있지만, 보안 강화를 위해 컨테이너 레벨에서 설정하는 것이 좋습니다. (Junwoo)
+          startupProbe:
+            exec:
+              command:
+                - python3
+                - /app/deploy/health_check.py
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 60
           readinessProbe:
             httpGet:
               path: /api/health

--- a/kubernetes/base/backend/deployment.yaml
+++ b/kubernetes/base/backend/deployment.yaml
@@ -86,7 +86,23 @@ spec:
                   name: common-credentials
                   key: AWS_SECRET_ACCESS_KEY
           # TODO: Security Context 설정을 추가해야 합니다. 현재 entrypoint.sh 에서 권한을 변경하고 있지만, 보안 강화를 위해 컨테이너 레벨에서 설정하는 것이 좋습니다. (Junwoo)
-          # TODO: Health Check Probe 설정이 필요합니다. 백엔드 쪽에서 수정이 필요하므로 추후에 반영하도록 하겠습니다. (Junwoo)
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: 8080
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command:
+                - python3
+                - /app/deploy/health_check.py
+            initialDelaySeconds: 60
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 3
           volumeMounts:
             - name: vol-log
               mountPath: /data/log


### PR DESCRIPTION
# Changelog

- 백엔드 헬스체크 API를 추가했습니다.
  - `GET /api/health`
  - 인증 없이 `204 No Content` 반환
- backend Deployment에 `readinessProbe`를 추가했습니다.
  - `/api/health`로 Pod 트래픽 수신 가능 여부 확인
- backend Deployment에 `livenessProbe`를 추가했습니다.
  - 기존 `deploy/health_check.py`로 supervisor/gunicorn 상태 확인

# Testing

- 확인 결과:
  - Python 문법 검사 통과
  - YAML 파싱 통과
  - `readinessProbe`, `livenessProbe` 설정 확인 완료

# Ops Impact

- backend Pod 롤링 업데이트가 발생합니다.
- DB 마이그레이션은 없습니다.
- readiness 통과 전까지 신규 Pod는 Service 트래픽을 받지 않습니다.
- liveness 실패 시 비정상 backend Pod가 자동 재시작됩니다.

# Version Compatibility

N/A