### PR TITLE
#686 상단 히어로 카드 개최 된 대회 수정

### DIFF
--- a/backend/contents/tests.py
+++ b/backend/contents/tests.py
@@ -1,21 +1,56 @@
+import copy
+from datetime import timedelta
+
+from django.core.cache import cache
+from django.utils import timezone
+
+from contest.models import Contest
+from contest.tests import DEFAULT_CONTEST_DATA
 from utils.api.tests import APITestCase
 
 
 class GetHomeStatisticsAPITest(APITestCase):
     """
-    홈 화면 컨텐츠(총 문제 수, 풀린 문제 수, 진행된 대회 수) API 테스트
+    홈 화면 컨텐츠(총 문제 수, 풀린 문제 수, 개최된 대회 수) API 테스트
     """
 
     def setUp(self):
         self.create_school_fixtures(college_id=1, college_name="Test", department_id=1, department_name="Test")
-        """
-        임시 테스트 코드
-        """
+        self.admin = self.create_admin()
         self.url = self.reverse("home_statistics")
 
-    def test_get_home_ranking_with_sufficient_data(self):
+    def _create_contest(self, title, start_delta, end_delta, visible=True):
+        now = timezone.now()
+        data = copy.deepcopy(DEFAULT_CONTEST_DATA)
+        data.update({
+            "title": title,
+            "start_time": now + start_delta,
+            "end_time": now + end_delta,
+            "visible": visible,
+        })
+        return Contest.objects.create(created_by=self.admin, **data)
+
+    def test_get_home_statistics_success(self):
         resp = self.client.get(self.url)
         self.assertSuccess(resp)
+
+    def test_ended_contest_length_counts_started_contests_only(self):
+        # 종료된 대회 (시작·종료 모두 과거) → 포함
+        self._create_contest("ended", timedelta(days=-2), timedelta(days=-1))
+        # 진행중인 대회 (시작했고 아직 안 끝남) → 개최된 것으로 포함
+        self._create_contest("ongoing", timedelta(hours=-1), timedelta(hours=1))
+        # 예정 대회 (아직 시작 전) → 제외
+        self._create_contest("not_started", timedelta(days=1), timedelta(days=2))
+        # 시작했지만 비공개 (visible=False) → 제외
+        self._create_contest("hidden", timedelta(days=-2), timedelta(days=-1), visible=False)
+
+        # 뷰가 결과를 10분 캐싱하므로, 캐시를 비워 새로 계산되도록 함
+        cache.clear()
+
+        resp = self.client.get(self.url)
+        self.assertSuccess(resp)
+        # 종료(ended) + 진행중(ongoing) = 2, 예정/비공개는 제외
+        self.assertEqual(resp.data["data"]["ended_contest_length"], 2)
 
 
 class GetHomeAnnouncementsAPITest(APITestCase):

--- a/backend/contents/views/oj.py
+++ b/backend/contents/views/oj.py
@@ -28,7 +28,8 @@ class GetHomeStatisticsAPI(APIView):
         total_problem_length = problems.count()
         accepted_problem_length = problems.filter(accepted_number__gt=0).count()
 
-        ended_contest_length = Contest.objects.filter(visible=True).count()
+        # 개최된 대회 수: 이미 시작된 대회(진행중 + 종료)를 집계, 아직 시작 전인 예정 대회는 제외
+        ended_contest_length = Contest.objects.filter(visible=True, start_time__lte=now()).count()
 
         home_statistics = {
             "total_problem_length": total_problem_length,


### PR DESCRIPTION


# Changelog
- 개최 된 대회 값이 개최 중인 대회 값으로 불러오던 것을 개최 된 (진행 중 + 종료 된) 대회의 수로 불로오도록 백엔드 코드 수정
- 수정된 백엔드 코드 + contest 테스트 코드 작성
<!-- 이 PR에서 변경된 내용을 자세하게 기술해주세요. -->
<!-- 추가/수정/삭제된 기능이나 버그 수정 사항을 명확히 작성해주세요. -->

# Testing
<img width="2264" height="860" alt="image" src="https://github.com/user-attachments/assets/9e8fc8b0-6e6e-4445-b6ed-2db135afe6cd" />


<img width="1364" height="376" alt="image" src="https://github.com/user-attachments/assets/dfdbf23e-3c0c-4095-a370-1b2d3e974bd6" />


<!-- 테스트 방법과 결과를 상세히 기술해주세요. -->
<!-- 단위 테스트, 통합 테스트 결과나 수동 테스트 내용을 포함해주세요. -->
<!-- 스크린샷이나 로그도 첨부하면 좋습니다. -->

# Ops Impact
N/A
<!-- 이 변경사항이 운영에 미치는 영향을 설명해주세요. -->
<!-- 서버 재시작이 필요한지, DB 마이그레이션이 있는지, 성능에 영향을 주는지 등 운영팀이 알아야 할 사항을 기재해주세요. -->
<!-- 해당 사항이 없다면 N/A로 기재해주세요. -->

# Version Compatibility
N/A
<!-- 이 변경사항이 기존 버전과의 호환성에 영향을 주는지 설명해주세요. -->
<!-- 하위/상위 버전 호환성 이슈가 있는지, 클라이언트/서버 버전 동기화가 필요한지 등을 기재해주세요. -->
<!-- 해당 사항이 없다면 N/A로 기재해주세요. -->
