### PR TITLE
#699 백엔드 Sentry SDK 연동 추가

### DIFF
--- a/backend/deploy/requirements.txt
+++ b/backend/deploy/requirements.txt
@@ -17,6 +17,7 @@ pillow==12.2.0
 psycopg2==2.9.9
 python-dateutil==2.9.0.post0
 qrcode==8.2
+sentry-sdk==2.63.0
 XlsxWriter==3.2.9
 yapf==0.43.0
 celery==5.6.3

--- a/backend/oj/settings.py
+++ b/backend/oj/settings.py
@@ -24,7 +24,7 @@ else:
 
 SENTRY_DSN = get_env(
     "SENTRY_DSN",
-    "https://d3a5abd2562994de8fae7fca4988680a@o4511586463776768.ingest.us.sentry.io/4511586479308800",
+    "",
 )
 if SENTRY_DSN:
     sentry_sdk.init(

--- a/backend/oj/settings.py
+++ b/backend/oj/settings.py
@@ -14,12 +14,24 @@ from copy import deepcopy
 from utils.shortcuts import get_env
 
 import celery.schedules
+import sentry_sdk
 
 production_env = get_env("OJ_ENV", "dev") == "production"
 if production_env:
     from .production_settings import *
 else:
     from .dev_settings import *
+
+SENTRY_DSN = get_env(
+    "SENTRY_DSN",
+    "https://d3a5abd2562994de8fae7fca4988680a@o4511586463776768.ingest.us.sentry.io/4511586479308800",
+)
+if SENTRY_DSN:
+    sentry_sdk.init(
+        dsn=SENTRY_DSN,
+        send_default_pii=True,
+        environment=get_env("SENTRY_ENVIRONMENT", get_env("OJ_ENV", "dev")),
+    )
 
 with open(os.path.join(DATA_DIR, "config", "secret.key"), "r") as f:
     SECRET_KEY = f.read()

--- a/deployment/.env.example
+++ b/deployment/.env.example
@@ -5,6 +5,8 @@ POSTGRES_PASSWORD=your_postgres_password
 
 # Django
 CSRF_TRUSTED_ORIGINS=https://example.com
+SENTRY_DSN=https://examplePublicKey@o0.ingest.sentry.io/0
+SENTRY_ENVIRONMENT=production
 
 # Code Place Hub
 GITHUB_OAUTH_APP_ID=your_github_oauth_app_id

--- a/kubernetes/overlays/dev/backend-deployment-patch.yaml
+++ b/kubernetes/overlays/dev/backend-deployment-patch.yaml
@@ -10,3 +10,5 @@ spec:
           env:
             - name: CSRF_TRUSTED_ORIGINS
               value: "https://k3s.code-place-dev.site"
+            - name: SENTRY_ENVIRONMENT
+              value: "dev"

--- a/kubernetes/overlays/dev/celery-beat-deployment-patch.yaml
+++ b/kubernetes/overlays/dev/celery-beat-deployment-patch.yaml
@@ -8,3 +8,10 @@ spec:
   replicas: 1
   strategy:
     type: Recreate
+  template:
+    spec:
+      containers:
+        - name: celery-beat
+          env:
+            - name: SENTRY_ENVIRONMENT
+              value: "dev"

--- a/kubernetes/overlays/dev/celery-worker-deployment-patch.yaml
+++ b/kubernetes/overlays/dev/celery-worker-deployment-patch.yaml
@@ -11,3 +11,10 @@ spec:
     rollingUpdate:
       maxUnavailable: 0
       maxSurge: 1
+  template:
+    spec:
+      containers:
+        - name: celery-worker
+          env:
+            - name: SENTRY_ENVIRONMENT
+              value: "dev"

--- a/kubernetes/overlays/prod/backend-deployment-patch.yaml
+++ b/kubernetes/overlays/prod/backend-deployment-patch.yaml
@@ -17,3 +17,5 @@ spec:
           env:
             - name: CSRF_TRUSTED_ORIGINS
               value: "https://code.pusan.ac.kr"
+            - name: SENTRY_ENVIRONMENT
+              value: "prod"

--- a/kubernetes/overlays/prod/celery-beat-deployment-patch.yaml
+++ b/kubernetes/overlays/prod/celery-beat-deployment-patch.yaml
@@ -8,3 +8,10 @@ spec:
   replicas: 1
   strategy:
     type: Recreate
+  template:
+    spec:
+      containers:
+        - name: celery-beat
+          env:
+            - name: SENTRY_ENVIRONMENT
+              value: "prod"

--- a/kubernetes/overlays/prod/celery-worker-deployment-patch.yaml
+++ b/kubernetes/overlays/prod/celery-worker-deployment-patch.yaml
@@ -11,3 +11,10 @@ spec:
     rollingUpdate:
       maxUnavailable: 1
       maxSurge: 1
+  template:
+    spec:
+      containers:
+        - name: celery-worker
+          env:
+            - name: SENTRY_ENVIRONMENT
+              value: "prod"


### PR DESCRIPTION
# Changelog

- Django 백엔드에 `sentry-sdk` 의존성을 추가했습니다.
- `SENTRY_DSN` 환경변수가 설정된 경우 Sentry SDK를 초기화하도록 설정했습니다.
- `SENTRY_ENVIRONMENT`로 dev/prod 환경을 구분하도록 했습니다.
- dev/prod k8s backend, celery worker, celery beat 설정에 Sentry environment 값을 추가했습니다.

# Testing

- `pip install -r backend/deploy/requirements.txt` 성공
- `SENTRY_DSN=` 상태에서 `python manage.py check` 성공

# Ops Impact

- 서버 재시작 또는 재배포가 필요합니다.
- DB 마이그레이션은 없습니다.
- Sentry 전송을 활성화하려면 운영 환경에 `SENTRY_DSN` 설정이 필요합니다.
- `SENTRY_DSN`이 비어 있으면 Sentry는 비활성화되고 기존 동작과 동일합니다.

# Version Compatibility

- API 응답이나 DB 스키마 변경은 없습니다.
- 클라이언트/서버 버전 동기화는 필요하지 않습니다.
- 백엔드 런타임 의존성에 `sentry-sdk`가 추가됩니다.