### PR TITLE
#540 서비스 관측성(LGTM) 계측 추가 

### DIFF
--- a/backend/account/middleware.py
+++ b/backend/account/middleware.py
@@ -1,3 +1,7 @@
+import logging
+import time
+import uuid
+
 from django.conf import settings
 from django.contrib.auth import user_logged_in
 from django.db import connection
@@ -6,7 +10,83 @@ from django.utils.timezone import now
 from django.utils.deprecation import MiddlewareMixin
 
 from utils.api import JSONResponse
+from utils.observability_context import reset_request_id, set_request_id
+from utils.observability_metrics import HTTP_REQUEST_DURATION_SECONDS, HTTP_REQUESTS_TOTAL
 from account.models import User
+
+request_logger = logging.getLogger("codeplace.request")
+MAX_REQUEST_ID_LENGTH = 128
+
+
+class RequestIDMiddleware:
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        request_id = self._request_id(request)
+        request.request_id = request_id
+        token = set_request_id(request_id)
+        try:
+            response = self.get_response(request)
+            response["X-Request-ID"] = request_id
+            return response
+        finally:
+            reset_request_id(token)
+
+    @staticmethod
+    def _request_id(request):
+        request_id = request.META.get("HTTP_X_REQUEST_ID")
+        if not request_id:
+            return uuid.uuid4().hex
+        return request_id[:MAX_REQUEST_ID_LENGTH]
+
+
+class RequestLogMiddleware:
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        started_at = time.monotonic()
+        response = None
+        try:
+            response = self.get_response(request)
+            return response
+        finally:
+            duration_seconds = time.monotonic() - started_at
+            status_code = getattr(response, "status_code", 500)
+            if request.path not in ("/metrics", "/api/health"):
+                endpoint = self._endpoint(request)
+                HTTP_REQUESTS_TOTAL.labels(request.method, endpoint, str(status_code)).inc()
+                HTTP_REQUEST_DURATION_SECONDS.labels(request.method, endpoint).observe(duration_seconds)
+                request_logger.info(
+                    "request completed",
+                    extra={
+                        "request_id": getattr(request, "request_id", None),
+                        "method": request.method,
+                        "path": request.path,
+                        "status_code": status_code,
+                        "duration_ms": round(duration_seconds * 1000, 2),
+                        "user_id": self._user_id(request),
+                        "remote_addr": getattr(request, "ip", request.META.get(settings.IP_HEADER,
+                                                                               request.META.get("REMOTE_ADDR"))),
+                    },
+                )
+
+    @staticmethod
+    def _endpoint(request):
+        resolver_match = getattr(request, "resolver_match", None)
+        if not resolver_match:
+            return "unknown"
+        return resolver_match.view_name or getattr(resolver_match, "route", None) or "unknown"
+
+    @staticmethod
+    def _user_id(request):
+        user = getattr(request, "user", None)
+        if user is not None and getattr(user, "is_authenticated", False):
+            return getattr(user, "id", None)
+        return None
 
 
 class APITokenAuthMiddleware(MiddlewareMixin):

--- a/backend/deploy/requirements.txt
+++ b/backend/deploy/requirements.txt
@@ -21,3 +21,12 @@ XlsxWriter==3.2.9
 yapf==0.43.0
 celery==5.6.3
 django-celery-beat==2.9.0
+django-prometheus==2.5.0
+opentelemetry-api==1.42.1
+opentelemetry-exporter-otlp==1.42.1
+opentelemetry-instrumentation-celery==0.63b1
+opentelemetry-instrumentation-django==0.63b1
+opentelemetry-instrumentation-psycopg2==0.63b1
+opentelemetry-instrumentation-redis==0.63b1
+opentelemetry-instrumentation-requests==0.63b1
+opentelemetry-sdk==1.42.1

--- a/backend/judge/dispatcher.py
+++ b/backend/judge/dispatcher.py
@@ -10,6 +10,7 @@ import requests
 from django.db import transaction, IntegrityError
 from django.db.models import F
 from django.http import HttpResponseNotFound
+from opentelemetry import trace
 
 from account.models import User, UserScore, UserSolved
 from conf.models import JudgeServer
@@ -22,6 +23,7 @@ from utils.cache import cache
 from utils.constants import CacheKey, ProblemScore, ProblemField, Tier
 
 logger = logging.getLogger(__name__)
+tracer = trace.get_tracer(__name__)
 
 
 # 继续处理在队列中的问题
@@ -68,10 +70,13 @@ class DispatcherBase(object):
         if data:
             kwargs["json"] = data
         try:
-            print("_request:", url)
-            return requests.post(url, **kwargs).json()
-        except Exception as e:
-            logger.exception(e)
+            with tracer.start_as_current_span("judge_server.request") as span:
+                span.set_attribute("http.url", url)
+                resp = requests.post(url, **kwargs)
+                span.set_attribute("http.status_code", resp.status_code)
+                return resp.json()
+        except Exception:
+            logger.exception("Failed to call judge-server")
 
 
 class SPJCompiler(DispatcherBase):
@@ -131,6 +136,12 @@ class JudgeDispatcher(DispatcherBase):
             self.submission.statistic_info["score"] = score
 
     def judge(self):
+        with tracer.start_as_current_span("submission.judge") as span:
+            span.set_attribute("codeplace.submission_id", self.submission.id)
+            span.set_attribute("codeplace.problem_id", self.problem.id)
+            self._judge(span)
+
+    def _judge(self, span):
         language = self.submission.language
         sub_config = list(filter(lambda item: language == item["name"], SysOptions.languages))[0]
         spj_config = {}
@@ -165,7 +176,9 @@ class JudgeDispatcher(DispatcherBase):
             if not server:
                 data = {"submission_id": self.submission.id, "problem_id": self.problem.id}
                 cache.lpush(CacheKey.waiting_queue, json.dumps(data))
+                span.set_attribute("codeplace.judge.queued", True)
                 return
+            span.set_attribute("codeplace.judge_server.hostname", server.hostname)
             Submission.objects.filter(id=self.submission.id).update(result=JudgeStatus.JUDGING)
             self.submission.judge_start_time = timezone.now()
             resp = self._request(urljoin(server.service_url, "/judge"), data=data)
@@ -173,6 +186,7 @@ class JudgeDispatcher(DispatcherBase):
 
         if not resp:
             Submission.objects.filter(id=self.submission.id).update(result=JudgeStatus.SYSTEM_ERROR)
+            span.set_attribute("codeplace.judge.result", "system_error")
             return
 
         if resp["err"]:
@@ -198,6 +212,7 @@ class JudgeDispatcher(DispatcherBase):
                 else:
                     self.submission.result = JudgeStatus.PARTIALLY_ACCEPTED
         self.submission.save()
+        span.set_attribute("codeplace.judge.result", self.submission.result)
 
         if self.contest_id:
             if self.contest.status != ContestStatus.CONTEST_UNDERWAY or \

--- a/backend/judge/tasks.py
+++ b/backend/judge/tasks.py
@@ -1,14 +1,21 @@
 import celery
+from opentelemetry import trace
 
 from account.models import User
 from utils.shortcuts import CELERY_TASK_ARGS
 from submission.models import Submission
 from judge.dispatcher import JudgeDispatcher
 
+tracer = trace.get_tracer(__name__)
+
 
 @celery.shared_task(**CELERY_TASK_ARGS())
 def judge_task(submission_id, problem_id):
-    uid = Submission.objects.get(id=submission_id).user_id
-    if User.objects.get(id=uid).is_disabled:
-        return
-    JudgeDispatcher(submission_id, problem_id).judge()
+    with tracer.start_as_current_span("judge_task") as span:
+        span.set_attribute("codeplace.submission_id", submission_id)
+        span.set_attribute("codeplace.problem_id", problem_id)
+        uid = Submission.objects.get(id=submission_id).user_id
+        if User.objects.get(id=uid).is_disabled:
+            span.set_attribute("codeplace.judge.skipped", "user_disabled")
+            return
+        JudgeDispatcher(submission_id, problem_id).judge()

--- a/backend/oj/celery.py
+++ b/backend/oj/celery.py
@@ -1,7 +1,10 @@
 import os
 import celery
 
+from utils.observability_tracing import configure_opentelemetry
+
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'oj.settings')
+configure_opentelemetry("codeplace-celery")
 
 app = celery.Celery('scheduler')
 app.config_from_object('django.conf:settings', namespace='CELERY')

--- a/backend/oj/dev_settings.py
+++ b/backend/oj/dev_settings.py
@@ -6,7 +6,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'ENGINE': 'django_prometheus.db.backends.postgresql',
         'HOST': get_env('POSTGRES_HOST', '127.0.0.1'),
         'PORT': get_env('POSTGRES_PORT', '5435'),
         'NAME': get_env('POSTGRES_DB', 'onlinejudge'),

--- a/backend/oj/production_settings.py
+++ b/backend/oj/production_settings.py
@@ -2,7 +2,7 @@ from utils.shortcuts import get_env
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'ENGINE': 'django_prometheus.db.backends.postgresql',
         'HOST': get_env("POSTGRES_HOST", "oj-postgres"),
         'PORT': get_env("POSTGRES_PORT", "5432"),
         'NAME': get_env("POSTGRES_DB"),

--- a/backend/oj/settings.py
+++ b/backend/oj/settings.py
@@ -28,6 +28,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # Applications
 VENDOR_APPS = [
+    'django_prometheus',
     'django.contrib.auth',
     'django.contrib.sessions',
     'django.contrib.contenttypes',
@@ -60,6 +61,8 @@ LOCAL_APPS = [
 INSTALLED_APPS = VENDOR_APPS + LOCAL_APPS
 
 MIDDLEWARE = (
+    'django_prometheus.middleware.PrometheusBeforeMiddleware',
+    'account.middleware.RequestIDMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -69,6 +72,8 @@ MIDDLEWARE = (
     'django.middleware.security.SecurityMiddleware',
     'account.middleware.AdminRoleRequiredMiddleware',
     'account.middleware.SessionRecordMiddleware',
+    'account.middleware.RequestLogMiddleware',
+    'django_prometheus.middleware.PrometheusAfterMiddleware',
     # 'account.middleware.LogSqlMiddleware',
 )
 
@@ -146,6 +151,12 @@ POPUP_DIR = f"{DATA_DIR}{POPUP_URI_PREFIX}"
 
 STATICFILES_DIRS = [os.path.join(DATA_DIR, "public")]
 
+
+def env_to_bool(name, default=False):
+    value = get_env(name, str(default)).lower()
+    return value in ("1", "true", "yes", "on")
+
+
 LOGGING_HANDLERS = ['console']
 LOGGING = {
     'version': 1,
@@ -154,13 +165,16 @@ LOGGING = {
         'standard': {
             'format': '[%(asctime)s] - [%(levelname)s] - [%(name)s:%(lineno)d]  - %(message)s',
             'datefmt': '%Y-%m-%d %H:%M:%S'
+        },
+        'json': {
+            '()': 'utils.json_logging.CodePlaceJsonFormatter',
         }
     },
     'handlers': {
         'console': {
             'level': 'DEBUG',
             'class': 'logging.StreamHandler',
-            'formatter': 'standard'
+            'formatter': 'json' if env_to_bool("JSON_LOGGING", production_env) else 'standard'
         }
     },
     'loggers': {
@@ -174,6 +188,11 @@ LOGGING = {
             'level': 'ERROR',
             'propagate': True,
         },
+        'codeplace.request': {
+            'handlers': LOGGING_HANDLERS,
+            'level': 'INFO',
+            'propagate': False,
+        },
         '': {
             'handlers': LOGGING_HANDLERS,
             'level': 'WARNING',
@@ -186,11 +205,6 @@ REST_FRAMEWORK = {
     'TEST_REQUEST_DEFAULT_FORMAT': 'json',
     'DEFAULT_RENDERER_CLASSES': ('rest_framework.renderers.JSONRenderer',)
 }
-
-def env_to_bool(name, default=False):
-    value = get_env(name, str(default)).lower()
-    return value in ("1", "true", "yes", "on")
-
 
 def parse_host_port_list(value, default_port):
     hosts = []

--- a/backend/oj/urls.py
+++ b/backend/oj/urls.py
@@ -1,6 +1,11 @@
 from django.urls import include, re_path
 
+from utils.observability_metrics import register_codeplace_metrics
+
+register_codeplace_metrics()
+
 urlpatterns = [
+    re_path(r"^", include("django_prometheus.urls")),
     re_path(r"^api/", include("account.urls.oj")),
     re_path(r"^api/admin/", include("account.urls.admin")),
     re_path(r"^api/", include("announcement.urls.oj")),

--- a/backend/oj/wsgi.py
+++ b/backend/oj/wsgi.py
@@ -11,6 +11,9 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
+from utils.observability_tracing import configure_opentelemetry
+
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "oj.settings")
+configure_opentelemetry("codeplace-backend")
 
 application = get_wsgi_application()

--- a/backend/utils/json_logging.py
+++ b/backend/utils/json_logging.py
@@ -1,0 +1,59 @@
+import json
+import logging
+from datetime import datetime, timezone
+
+from utils.observability_context import get_request_id
+
+
+SENSITIVE_FIELDS = {
+    "authorization",
+    "cookie",
+    "password",
+    "token",
+    "secret",
+    "code",
+    "src",
+}
+
+
+class CodePlaceJsonFormatter(logging.Formatter):
+
+    def format(self, record):
+        payload = {
+            "timestamp": datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+            "request_id": getattr(record, "request_id", None) or get_request_id(),
+        }
+        for key in (
+                "method",
+                "path",
+                "status_code",
+                "duration_ms",
+                "user_id",
+                "remote_addr",
+                "task_id",
+                "submission_id",
+        ):
+            value = getattr(record, key, None)
+            if value is not None:
+                payload[key] = value
+        if record.exc_info:
+            payload["exception"] = self.formatException(record.exc_info)
+        return json.dumps(self._redact(payload), ensure_ascii=False, default=str)
+
+    def _redact(self, value):
+        if isinstance(value, dict):
+            return {
+                key: "[REDACTED]" if self._is_sensitive_key(key) else self._redact(item)
+                for key, item in value.items()
+            }
+        if isinstance(value, list):
+            return [self._redact(item) for item in value]
+        return value
+
+    @staticmethod
+    def _is_sensitive_key(key):
+        normalized = str(key).lower()
+        return any(field in normalized for field in SENSITIVE_FIELDS)

--- a/backend/utils/json_logging.py
+++ b/backend/utils/json_logging.py
@@ -5,13 +5,24 @@ from datetime import datetime, timezone
 from utils.observability_context import get_request_id
 
 
-SENSITIVE_FIELDS = {
+SENSITIVE_EXACT_FIELDS = {
     "authorization",
     "cookie",
     "password",
     "token",
     "secret",
     "code",
+    "src",
+}
+SENSITIVE_SUBSTRINGS = {
+    "authorization",
+    "cookie",
+    "password",
+    "token",
+    "secret",
+    "source_code",
+    "sourcecode",
+    "spj_code",
     "src",
 }
 
@@ -56,4 +67,4 @@ class CodePlaceJsonFormatter(logging.Formatter):
     @staticmethod
     def _is_sensitive_key(key):
         normalized = str(key).lower()
-        return any(field in normalized for field in SENSITIVE_FIELDS)
+        return normalized in SENSITIVE_EXACT_FIELDS or any(field in normalized for field in SENSITIVE_SUBSTRINGS)

--- a/backend/utils/observability_context.py
+++ b/backend/utils/observability_context.py
@@ -1,0 +1,16 @@
+import contextvars
+
+
+request_id_var = contextvars.ContextVar("request_id", default=None)
+
+
+def get_request_id():
+    return request_id_var.get()
+
+
+def set_request_id(request_id):
+    return request_id_var.set(request_id)
+
+
+def reset_request_id(token):
+    request_id_var.reset(token)

--- a/backend/utils/observability_metrics.py
+++ b/backend/utils/observability_metrics.py
@@ -130,9 +130,11 @@ class CodePlaceCollector:
             logger.warning("Failed to collect judge-server metrics: %s", e)
             servers = []
         for server in servers:
+            if server.is_disabled:
+                continue
             hostname = server.hostname or "unknown"
             heartbeat_age = max((now - server.last_heartbeat).total_seconds(), 0)
-            available = 1 if not server.is_disabled and server.status == "normal" else 0
+            available = 1 if server.status == "normal" else 0
             available_metric.add_metric([hostname], available)
             heartbeat_metric.add_metric([hostname], heartbeat_age)
             task_metric.add_metric([hostname], server.task_number)

--- a/backend/utils/observability_metrics.py
+++ b/backend/utils/observability_metrics.py
@@ -1,0 +1,176 @@
+import logging
+from datetime import timedelta
+
+from django.db.models import Count
+from django.utils import timezone
+from prometheus_client import Counter, Histogram, REGISTRY
+from prometheus_client.core import GaugeMetricFamily, HistogramMetricFamily
+
+from submission.models import JudgeStatus, Submission
+from utils.cache import cache
+from utils.constants import CacheKey
+
+logger = logging.getLogger(__name__)
+
+JUDGE_DURATION_BUCKETS = (1, 3, 5, 10, 30, 60, 120, 300, 600, float("inf"))
+JUDGE_STATUS_LABELS = {
+    JudgeStatus.COMPILE_ERROR: "compile_error",
+    JudgeStatus.WRONG_ANSWER: "wrong_answer",
+    JudgeStatus.ACCEPTED: "accepted",
+    JudgeStatus.CPU_TIME_LIMIT_EXCEEDED: "cpu_time_limit_exceeded",
+    JudgeStatus.REAL_TIME_LIMIT_EXCEEDED: "real_time_limit_exceeded",
+    JudgeStatus.MEMORY_LIMIT_EXCEEDED: "memory_limit_exceeded",
+    JudgeStatus.RUNTIME_ERROR: "runtime_error",
+    JudgeStatus.SYSTEM_ERROR: "system_error",
+    JudgeStatus.PENDING: "pending",
+    JudgeStatus.JUDGING: "judging",
+    JudgeStatus.PARTIALLY_ACCEPTED: "partially_accepted",
+}
+
+HTTP_REQUESTS_TOTAL = Counter(
+    "codeplace_http_requests_total",
+    "Total backend HTTP requests.",
+    ["method", "endpoint", "status_code"],
+)
+HTTP_REQUEST_DURATION_SECONDS = Histogram(
+    "codeplace_http_request_duration_seconds",
+    "Backend HTTP request duration.",
+    ["method", "endpoint"],
+    buckets=(0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10),
+)
+
+
+class CodePlaceCollector:
+
+    def describe(self):
+        yield GaugeMetricFamily(
+            "codeplace_submission_status_count",
+            "Current number of submissions grouped by judge status.",
+            labels=["status"],
+        )
+        yield GaugeMetricFamily(
+            "codeplace_waiting_queue_length",
+            "Number of submissions waiting because no judge-server was available.",
+        )
+        yield GaugeMetricFamily(
+            "codeplace_judge_server_available",
+            "Whether each judge-server is enabled and has a fresh heartbeat.",
+            labels=["hostname"],
+        )
+        yield GaugeMetricFamily(
+            "codeplace_judge_server_last_heartbeat_age_seconds",
+            "Seconds since the latest judge-server heartbeat.",
+            labels=["hostname"],
+        )
+        yield GaugeMetricFamily(
+            "codeplace_judge_server_task_number",
+            "Current task_number recorded for each judge-server.",
+            labels=["hostname"],
+        )
+        yield HistogramMetricFamily(
+            "codeplace_submission_judge_duration_seconds",
+            "Judge duration for submissions completed in the last 10 minutes.",
+        )
+
+    def collect(self):
+        yield from self._submission_status_count()
+        yield self._waiting_queue_length()
+        yield from self._judge_server_metrics()
+        yield self._judge_duration_histogram()
+
+    def _submission_status_count(self):
+        metric = GaugeMetricFamily(
+            "codeplace_submission_status_count",
+            "Current number of submissions grouped by judge status.",
+            labels=["status"],
+        )
+        try:
+            counts = dict(Submission.objects.values_list("result").order_by("result").annotate(count=Count("id")))
+        except Exception as e:
+            logger.warning("Failed to collect submission status counts: %s", e)
+            counts = {}
+        for status_value, status_label in JUDGE_STATUS_LABELS.items():
+            metric.add_metric([status_label], counts.get(status_value, 0))
+        yield metric
+
+    def _waiting_queue_length(self):
+        metric = GaugeMetricFamily(
+            "codeplace_waiting_queue_length",
+            "Number of submissions waiting because no judge-server was available.",
+        )
+        try:
+            metric.add_metric([], cache.llen(CacheKey.waiting_queue) or 0)
+        except Exception as e:
+            logger.warning("Failed to collect waiting queue length: %s", e)
+            metric.add_metric([], 0)
+        return metric
+
+    def _judge_server_metrics(self):
+        from conf.models import JudgeServer
+
+        available_metric = GaugeMetricFamily(
+            "codeplace_judge_server_available",
+            "Whether each judge-server is enabled and has a fresh heartbeat.",
+            labels=["hostname"],
+        )
+        heartbeat_metric = GaugeMetricFamily(
+            "codeplace_judge_server_last_heartbeat_age_seconds",
+            "Seconds since the latest judge-server heartbeat.",
+            labels=["hostname"],
+        )
+        task_metric = GaugeMetricFamily(
+            "codeplace_judge_server_task_number",
+            "Current task_number recorded for each judge-server.",
+            labels=["hostname"],
+        )
+        now = timezone.now()
+        try:
+            servers = list(JudgeServer.objects.all())
+        except Exception as e:
+            logger.warning("Failed to collect judge-server metrics: %s", e)
+            servers = []
+        for server in servers:
+            hostname = server.hostname or "unknown"
+            heartbeat_age = max((now - server.last_heartbeat).total_seconds(), 0)
+            available = 1 if not server.is_disabled and server.status == "normal" else 0
+            available_metric.add_metric([hostname], available)
+            heartbeat_metric.add_metric([hostname], heartbeat_age)
+            task_metric.add_metric([hostname], server.task_number)
+        yield available_metric
+        yield heartbeat_metric
+        yield task_metric
+
+    def _judge_duration_histogram(self):
+        metric = HistogramMetricFamily(
+            "codeplace_submission_judge_duration_seconds",
+            "Judge duration for submissions completed in the last 10 minutes.",
+        )
+        cutoff = timezone.now() - timedelta(minutes=10)
+        durations = []
+        try:
+            submissions = Submission.objects.filter(
+                judge_start_time__gte=cutoff,
+                judge_start_time__isnull=False,
+                judge_end_time__isnull=False,
+            ).only("judge_start_time", "judge_end_time")
+            for submission in submissions:
+                durations.append(max((submission.judge_end_time - submission.judge_start_time).total_seconds(), 0))
+        except Exception as e:
+            logger.warning("Failed to collect judge duration metrics: %s", e)
+
+        cumulative_buckets = []
+        for bucket in JUDGE_DURATION_BUCKETS:
+            label = "+Inf" if bucket == float("inf") else str(bucket)
+            cumulative_buckets.append((label, sum(1 for duration in durations if duration <= bucket)))
+        metric.add_metric([], cumulative_buckets, sum(durations))
+        return metric
+
+
+def register_codeplace_metrics():
+    if getattr(register_codeplace_metrics, "_registered", False):
+        return
+    try:
+        REGISTRY.register(CodePlaceCollector())
+    except ValueError:
+        logger.debug("CodePlace metrics collector is already registered")
+    register_codeplace_metrics._registered = True

--- a/backend/utils/observability_tracing.py
+++ b/backend/utils/observability_tracing.py
@@ -1,0 +1,47 @@
+import logging
+
+from utils.shortcuts import get_env
+
+logger = logging.getLogger(__name__)
+
+
+def configure_opentelemetry(service_name):
+    if get_env("OTEL_ENABLED", "0").lower() not in ("1", "true", "yes", "on"):
+        return
+
+    try:
+        from opentelemetry import trace
+        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+        from opentelemetry.instrumentation.celery import CeleryInstrumentor
+        from opentelemetry.instrumentation.django import DjangoInstrumentor
+        from opentelemetry.instrumentation.psycopg2 import Psycopg2Instrumentor
+        from opentelemetry.instrumentation.redis import RedisInstrumentor
+        from opentelemetry.instrumentation.requests import RequestsInstrumentor
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+        from opentelemetry.sdk.trace.sampling import ParentBased, TraceIdRatioBased
+    except Exception:
+        logger.exception("OpenTelemetry packages are unavailable")
+        return
+
+    try:
+        sampler_ratio = float(get_env("OTEL_TRACES_SAMPLER_ARG", "0.05"))
+    except ValueError:
+        logger.warning("Invalid OTEL_TRACES_SAMPLER_ARG; falling back to 0.05")
+        sampler_ratio = 0.05
+    sampler_ratio = min(max(sampler_ratio, 0), 1)
+    resource = Resource.create({
+        "service.name": service_name,
+        "deployment.environment": get_env("OJ_ENV", "dev"),
+    })
+    provider = TracerProvider(resource=resource, sampler=ParentBased(TraceIdRatioBased(sampler_ratio)))
+    endpoint = get_env("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel-collector.monitoring.svc.cluster.local:4317")
+    provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(endpoint=endpoint, insecure=True)))
+    trace.set_tracer_provider(provider)
+
+    DjangoInstrumentor().instrument()
+    RequestsInstrumentor().instrument()
+    Psycopg2Instrumentor().instrument()
+    RedisInstrumentor().instrument()
+    CeleryInstrumentor().instrument()

--- a/docs/content/developer/infra/observability-improvement-plan/_index.md
+++ b/docs/content/developer/infra/observability-improvement-plan/_index.md
@@ -1,0 +1,151 @@
+---
+date: 2026-06-19T00:00:00+09:00
+draft: false
+title: "Observability Improvement Plan"
+weight: 5
+---
+
+{{< callout >}}
+CodePlace 관측성 1차 구현은 Kubernetes 운영 환경을 기준으로 합니다. Docker Swarm monitoring 구성은 레거시로 유지하며 수정하지 않습니다.
+{{< /callout >}}
+
+## 1. 관측 대상
+
+관측 대상은 운영자가 장애 발생 후 1분 안에 알림을 받고, 5분 안에 원인 후보를 좁힐 수 있도록 다음 경로로 나눕니다.
+
+- **User Path:** Traefik/Ingress, frontend nginx, backend Django API.
+- **Submission/Judge Path:** submission 생성, Celery `judge_task`, Redis `waiting_queue`, judge-server heartbeat, judge-server `/judge` 호출, 결과 저장.
+- **Async Jobs:** celery-worker, celery-beat, scheduled tasks.
+- **Data Stores:** PostgreSQL/CNPG, Redis Sentinel.
+- **Platform:** backend/frontend/celery/judge Pod, node, PVC.
+- **Client/Error:** frontend runtime error, backend exception, request ID 기반 로그.
+
+## 2. 구현 내용
+
+### Metrics
+
+backend는 `django-prometheus` 기반 `/metrics` 엔드포인트를 제공합니다. 이 엔드포인트는 ServiceMonitor가 cluster 내부에서 scrape하며 외부 Ingress에는 연결하지 않습니다.
+
+추가된 CodePlace custom metrics는 다음과 같습니다.
+
+- `codeplace_http_requests_total{method,endpoint,status_code}`
+- `codeplace_http_request_duration_seconds{method,endpoint}`
+- `codeplace_submission_status_count{status}`
+- `codeplace_submission_judge_duration_seconds`
+- `codeplace_waiting_queue_length`
+- `codeplace_judge_server_available{hostname}`
+- `codeplace_judge_server_last_heartbeat_age_seconds{hostname}`
+- `codeplace_judge_server_task_number{hostname}`
+
+`/metrics`와 `/api/health` 요청은 API request rate/latency metric과 request completion log에서 제외합니다.
+
+### Logs
+
+backend는 `X-Request-ID`를 수용하고, 없으면 request ID를 생성한 뒤 응답 header로 반환합니다.
+
+Kubernetes backend/celery 환경에서는 `JSON_LOGGING=1`을 기본으로 설정합니다. JSON 로그 필드는 다음을 기준으로 합니다.
+
+- `timestamp`
+- `level`
+- `logger`
+- `message`
+- `request_id`
+- `method`
+- `path`
+- `status_code`
+- `duration_ms`
+- `user_id`
+- `remote_addr`
+- `task_id`
+- `submission_id`
+
+민감 정보는 로그에 싣지 않습니다. token, password, cookie, OAuth secret, authorization header, 제출 source code는 저장 대상이 아닙니다.
+
+frontend nginx의 Kubernetes 설정은 access log를 `/dev/stdout`, error log를 `/dev/stderr`로 출력합니다.
+
+### Tracing
+
+OpenTelemetry는 앱 초기화 코드에 내장되어 있지만 기본값은 `OTEL_ENABLED=0`입니다. dev/staging에서 먼저 활성화하고 collector/Tempo/sampling 확인 후 prod 활성화를 결정합니다.
+
+자동 계측 대상은 Django, requests, psycopg2, Redis, Celery입니다. 제출/채점 경로에는 manual span을 추가합니다.
+
+- `judge_task`
+- `submission.judge`
+- `judge_server.request`
+
+기본 sampling 값은 `OTEL_TRACES_SAMPLER_ARG=0.05`입니다.
+
+## 3. Kubernetes Monitoring
+
+신규 monitoring 리소스는 `kubernetes/base/monitoring` 아래에 둡니다.
+
+- `backend-service-monitor.yaml`: backend `/metrics` scrape, interval 15s.
+- `prometheus-rules.yaml`: P0/P1 fast alert rules.
+- `alertmanager-config.yaml`: P0/P1 Discord alert routing.
+- `grafana-dashboard-codeplace.yaml`: CodePlace overview dashboard.
+- `kube-prometheus-stack-values.yaml`: selector와 evaluation interval 기본값.
+
+`alertmanager-contact-points` Secret은 repo에 저장하지 않습니다. backend의 `/data/config/secret.key`와 같은 비밀값이지만, 자동으로 파일이 생기는 구조는 아닙니다. 운영자가 `kubectl create secret`으로 만들거나 ExternalSecrets/SealedSecrets 같은 Secret 주입 도구로 생성해야 합니다. AlertmanagerConfig는 generic webhook이 아니라 Prometheus Operator의 native `discordConfigs`를 사용합니다.
+
+## 4. 빠른 알림 정책
+
+### P0
+
+P0는 `group_wait=10s`, `repeat_interval=15m`로 Discord에 빠르게 전달합니다.
+
+- `BackendTargetDown`: backend scrape 실패 1분 지속.
+- `Api5xxSpike`: backend 5xx 비율 5% 초과 2분 지속.
+- `Ingress5xxSpike`: Traefik 5xx 비율 5% 초과 2분 지속.
+- `JudgeAllUnavailable`: 사용 가능한 judge-server 0개 1분 지속.
+- `JudgeHeartbeatCritical`: judge heartbeat age 180초 초과.
+- `PostgresUnavailable`: PostgreSQL Pod not ready 1분 지속.
+- `RedisUnavailable`: Redis Pod not ready 1분 지속.
+
+### P1
+
+P1은 `group_wait=30s`, `repeat_interval=1h`로 전달합니다.
+
+- `ApiLatencyHigh`: p95 latency 2초 초과 5분 지속.
+- `JudgeWaitingQueueBacklog`: `waiting_queue` 5 초과 3분 지속.
+- `CeleryWorkerRestarting`: worker restart 3회 이상/15분.
+- `CeleryBeatDown`: beat Pod not ready 2분 지속.
+- `PodCrashLooping`: 주요 Pod restart 증가 5분 지속.
+- `PVCAlmostFull`: PVC 사용률 85% 초과 10분 지속.
+
+## 5. 운영 확인 절차
+
+1. kube-prometheus-stack을 monitoring namespace에 설치할 때 `kubernetes/base/monitoring/kube-prometheus-stack-values.yaml`을 함께 적용합니다. Prometheus Operator CRD가 `AlertmanagerConfig.discordConfigs`를 지원하는 버전인지 확인합니다.
+2. `alertmanager-contact-points` Secret을 운영 클러스터의 `monitoring` namespace에 생성합니다. 이 값은 Kubernetes Secret으로 참조되며, Pod 파일로 mount하지 않습니다.
+3. Kubernetes base/overlay를 적용합니다.
+4. Prometheus target에서 `backend` ServiceMonitor가 healthy인지 확인합니다.
+5. Grafana의 `CodePlace Overview` dashboard에서 request rate, 5xx, latency, submission status, waiting queue, judge heartbeat panel을 확인합니다.
+6. test alert 또는 임시 rule로 P0 webhook 수신 시간이 1분 이내인지 확인합니다.
+
+운영 적용 전제는 다음과 같습니다.
+
+- `/metrics`는 cluster 내부 scrape 전용이며 외부 Ingress에 노출하지 않습니다.
+- Discord webhook URL은 Git에 저장하지 않습니다.
+- Docker Swarm monitoring 구성은 레거시로 유지하고 신규 관측성 리소스와 분리합니다.
+- OpenTelemetry는 `OTEL_ENABLED=0` 기본값을 유지하고 dev/staging에서 먼저 활성화합니다.
+- P0/P1 알림 라우팅은 AlertmanagerConfig로 관리하며 Grafana UI 수동 설정에 의존하지 않습니다.
+
+## 6. 검증
+
+로컬 검증 항목은 다음과 같습니다.
+
+- Python compile: `python3 -m compileall backend/account backend/judge backend/oj backend/utils`
+- Django check: `/tmp/code-place-backend-venv/bin/python manage.py check --settings=oj.settings`
+- Metrics endpoint: Django test client 기준 `/metrics` 200 및 `codeplace_*` metric 포함 확인
+- Kubernetes render: `kubectl kustomize kubernetes/base`
+
+`promtool`이 있는 환경에서는 `promtool check rules kubernetes/base/monitoring/prometheus-rules.yaml`도 실행합니다.
+
+### Discord Webhook Secret
+
+Discord webhook URL은 repo에 커밋하지 않습니다. 클러스터별로 다음 명령으로 생성합니다.
+
+```sh
+kubectl -n monitoring create secret generic alertmanager-contact-points \
+  --from-literal=webhook-url="$ALERT_WEBHOOK_URL" \
+  --dry-run=client -o yaml | kubectl apply -f -
+```

--- a/frontend/deploy/kube_nginx/nginx.conf
+++ b/frontend/deploy/kube_nginx/nginx.conf
@@ -3,7 +3,7 @@ daemon off;
 pid /tmp/nginx.pid;
 worker_processes auto;
 pcre_jit on;
-error_log /data/log/nginx_error.log warn;
+error_log /dev/stderr warn;
 
 events {
   worker_connections 1024;
@@ -25,7 +25,7 @@ http {
                   '$status $body_bytes_sent "$http_referer" '
                   '"$http_user_agent" "$http_x_forwarded_for"';
 
-  access_log /data/log/nginx_access.log main;
+  access_log /dev/stdout main;
 
   upstream backend {
     server backend:8080;

--- a/kubernetes/base/backend/deployment.yaml
+++ b/kubernetes/base/backend/deployment.yaml
@@ -91,6 +91,14 @@ spec:
                 secretKeyRef:
                   name: common-credentials
                   key: AWS_SECRET_ACCESS_KEY
+            - name: JSON_LOGGING
+              value: "1"
+            - name: OTEL_ENABLED
+              value: "0"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://otel-collector.monitoring.svc.cluster.local:4317"
+            - name: OTEL_TRACES_SAMPLER_ARG
+              value: "0.05"
           # TODO: Security Context 설정을 추가해야 합니다. 현재 entrypoint.sh 에서 권한을 변경하고 있지만, 보안 강화를 위해 컨테이너 레벨에서 설정하는 것이 좋습니다. (Junwoo)
           startupProbe:
             httpGet:

--- a/kubernetes/base/celery-beat/deployment.yaml
+++ b/kubernetes/base/celery-beat/deployment.yaml
@@ -86,3 +86,11 @@ spec:
                 secretKeyRef:
                   name: common-credentials
                   key: AWS_SECRET_ACCESS_KEY
+            - name: JSON_LOGGING
+              value: "1"
+            - name: OTEL_ENABLED
+              value: "0"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://otel-collector.monitoring.svc.cluster.local:4317"
+            - name: OTEL_TRACES_SAMPLER_ARG
+              value: "0.05"

--- a/kubernetes/base/celery-worker/deployment.yaml
+++ b/kubernetes/base/celery-worker/deployment.yaml
@@ -89,3 +89,11 @@ spec:
                 secretKeyRef:
                   name: common-credentials
                   key: AWS_SECRET_ACCESS_KEY
+            - name: JSON_LOGGING
+              value: "1"
+            - name: OTEL_ENABLED
+              value: "0"
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: "http://otel-collector.monitoring.svc.cluster.local:4317"
+            - name: OTEL_TRACES_SAMPLER_ARG
+              value: "0.05"

--- a/kubernetes/base/frontend/deployment.yaml
+++ b/kubernetes/base/frontend/deployment.yaml
@@ -43,13 +43,9 @@ spec:
             - name: SERVER_NAME
               value: "localhost"
           volumeMounts:
-            - name: vol-log
-              mountPath: /data/log
             - name: vol-public
               mountPath: /data/public
       volumes:
-        - name: vol-log
-          emptyDir: {}
         - name: vol-public
           persistentVolumeClaim:
             claimName: pvc-public

--- a/kubernetes/base/kustomization.yaml
+++ b/kubernetes/base/kustomization.yaml
@@ -5,6 +5,10 @@ kind: Kustomization
 resources:
   # Monitoring
   - ./monitoring/namespace.yaml
+  - ./monitoring/alertmanager-config.yaml
+  - ./monitoring/backend-service-monitor.yaml
+  - ./monitoring/grafana-dashboard-codeplace.yaml
+  - ./monitoring/prometheus-rules.yaml
 
   # Persistent Volume Claims
   - ./backend/pvc.yaml

--- a/kubernetes/base/monitoring/alertmanager-config.yaml
+++ b/kubernetes/base/monitoring/alertmanager-config.yaml
@@ -1,0 +1,52 @@
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  name: codeplace-alert-routing
+  namespace: monitoring
+  labels:
+    alertmanagerConfig: codeplace
+spec:
+  route:
+    groupBy:
+      - alertname
+      - priority
+    groupWait: 30s
+    groupInterval: 5m
+    repeatInterval: 1h
+    receiver: p1-discord
+    routes:
+      - matchers:
+          - name: priority
+            value: P0
+        groupWait: 10s
+        groupInterval: 1m
+        repeatInterval: 15m
+        receiver: p0-discord
+      - matchers:
+          - name: priority
+            value: P1
+        groupWait: 30s
+        groupInterval: 5m
+        repeatInterval: 1h
+        receiver: p1-discord
+  receivers:
+    - name: p0-discord
+      discordConfigs:
+        - sendResolved: true
+          apiURL:
+            name: alertmanager-contact-points
+            key: webhook-url
+          title: '[{{ .Status }}][P0] {{ .CommonLabels.alertname }}'
+          content: '{{ .CommonAnnotations.summary }}'
+          message: '{{ .CommonAnnotations.description }}'
+          username: CodePlace Alertmanager
+    - name: p1-discord
+      discordConfigs:
+        - sendResolved: true
+          apiURL:
+            name: alertmanager-contact-points
+            key: webhook-url
+          title: '[{{ .Status }}][P1] {{ .CommonLabels.alertname }}'
+          content: '{{ .CommonAnnotations.summary }}'
+          message: '{{ .CommonAnnotations.description }}'
+          username: CodePlace Alertmanager

--- a/kubernetes/base/monitoring/backend-service-monitor.yaml
+++ b/kubernetes/base/monitoring/backend-service-monitor.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: backend
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  namespaceSelector:
+    any: true
+  selector:
+    matchLabels:
+      app: backend
+  jobLabel: app
+  endpoints:
+    - port: api
+      path: /metrics
+      interval: 15s
+      scrapeTimeout: 10s

--- a/kubernetes/base/monitoring/grafana-dashboard-codeplace.yaml
+++ b/kubernetes/base/monitoring/grafana-dashboard-codeplace.yaml
@@ -1,0 +1,71 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-codeplace
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "1"
+data:
+  codeplace-overview.json: |
+    {
+      "uid": "codeplace-overview",
+      "title": "CodePlace Overview",
+      "schemaVersion": 39,
+      "version": 1,
+      "refresh": "30s",
+      "tags": ["codeplace"],
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "panels": [
+        {
+          "type": "timeseries",
+          "title": "Backend Request Rate",
+          "gridPos": {"x": 0, "y": 0, "w": 8, "h": 8},
+          "targets": [
+            {"expr": "sum(rate(codeplace_http_requests_total[5m]))", "legendFormat": "requests/s"}
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "Backend 5xx Rate",
+          "gridPos": {"x": 8, "y": 0, "w": 8, "h": 8},
+          "targets": [
+            {"expr": "sum(rate(codeplace_http_requests_total{status_code=~\"5..\"}[5m]))", "legendFormat": "5xx/s"}
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "Backend p95 Latency",
+          "gridPos": {"x": 16, "y": 0, "w": 8, "h": 8},
+          "targets": [
+            {"expr": "histogram_quantile(0.95, sum(rate(codeplace_http_request_duration_seconds_bucket[5m])) by (le))", "legendFormat": "p95"}
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "Submission Status",
+          "gridPos": {"x": 0, "y": 8, "w": 8, "h": 8},
+          "targets": [
+            {"expr": "codeplace_submission_status_count", "legendFormat": "{{status}}"}
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "Judge Waiting Queue",
+          "gridPos": {"x": 8, "y": 8, "w": 8, "h": 8},
+          "targets": [
+            {"expr": "codeplace_waiting_queue_length", "legendFormat": "waiting"}
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "Judge Heartbeat Age",
+          "gridPos": {"x": 16, "y": 8, "w": 8, "h": 8},
+          "targets": [
+            {"expr": "codeplace_judge_server_last_heartbeat_age_seconds", "legendFormat": "{{hostname}}"}
+          ]
+        }
+      ]
+    }

--- a/kubernetes/base/monitoring/kube-prometheus-stack-values.yaml
+++ b/kubernetes/base/monitoring/kube-prometheus-stack-values.yaml
@@ -1,0 +1,21 @@
+prometheus:
+  prometheusSpec:
+    evaluationInterval: 15s
+    scrapeInterval: 15s
+    serviceMonitorSelectorNilUsesHelmValues: false
+    ruleSelectorNilUsesHelmValues: false
+
+alertmanager:
+  alertmanagerSpec:
+    alertmanagerConfigSelector:
+      matchLabels:
+        alertmanagerConfig: codeplace
+    alertmanagerConfigNamespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: monitoring
+
+grafana:
+  sidecar:
+    dashboards:
+      enabled: true
+      label: grafana_dashboard

--- a/kubernetes/base/monitoring/prometheus-rules.yaml
+++ b/kubernetes/base/monitoring/prometheus-rules.yaml
@@ -1,0 +1,130 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: codeplace-fast-alerts
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: codeplace.p0
+      interval: 15s
+      rules:
+        - alert: BackendTargetDown
+          expr: up{job="backend"} == 0
+          for: 1m
+          labels:
+            severity: critical
+            priority: P0
+          annotations:
+            summary: "Backend metrics target is down"
+            description: "Prometheus cannot scrape the backend /metrics endpoint for 1 minute."
+        - alert: Api5xxSpike
+          expr: sum(rate(codeplace_http_requests_total{status_code=~"5.."}[2m])) / clamp_min(sum(rate(codeplace_http_requests_total[2m])), 1) > 0.05
+          for: 2m
+          labels:
+            severity: critical
+            priority: P0
+          annotations:
+            summary: "Backend API 5xx rate is high"
+            description: "Backend API 5xx responses are above 5% for 2 minutes."
+        - alert: Ingress5xxSpike
+          expr: sum(rate(traefik_service_requests_total{code=~"5.."}[2m])) / clamp_min(sum(rate(traefik_service_requests_total[2m])), 1) > 0.05
+          for: 2m
+          labels:
+            severity: critical
+            priority: P0
+          annotations:
+            summary: "Ingress 5xx rate is high"
+            description: "Traefik 5xx responses are above 5% for 2 minutes."
+        - alert: JudgeAllUnavailable
+          expr: absent(codeplace_judge_server_available) or sum(codeplace_judge_server_available) == 0
+          for: 1m
+          labels:
+            severity: critical
+            priority: P0
+          annotations:
+            summary: "No judge-server is available"
+            description: "No enabled judge-server has a fresh heartbeat."
+        - alert: JudgeHeartbeatCritical
+          expr: max(codeplace_judge_server_last_heartbeat_age_seconds) > 180
+          labels:
+            severity: critical
+            priority: P0
+          annotations:
+            summary: "Judge-server heartbeat is stale"
+            description: "A judge-server heartbeat is older than 180 seconds."
+        - alert: PostgresUnavailable
+          expr: min(kube_pod_status_ready{condition="true", pod=~"postgres-[0-9]+"}) == 0
+          for: 1m
+          labels:
+            severity: critical
+            priority: P0
+          annotations:
+            summary: "PostgreSQL pod is not ready"
+            description: "At least one PostgreSQL pod has not been ready for 1 minute."
+        - alert: RedisUnavailable
+          expr: min(kube_pod_status_ready{condition="true", pod=~"redis-.*|redis-replication-.*"}) == 0
+          for: 1m
+          labels:
+            severity: critical
+            priority: P0
+          annotations:
+            summary: "Redis pod is not ready"
+            description: "At least one Redis pod has not been ready for 1 minute."
+    - name: codeplace.p1
+      interval: 30s
+      rules:
+        - alert: ApiLatencyHigh
+          expr: histogram_quantile(0.95, sum(rate(codeplace_http_request_duration_seconds_bucket[5m])) by (le)) > 2
+          for: 5m
+          labels:
+            severity: warning
+            priority: P1
+          annotations:
+            summary: "Backend API p95 latency is high"
+            description: "Backend API p95 latency is above 2 seconds for 5 minutes."
+        - alert: JudgeWaitingQueueBacklog
+          expr: codeplace_waiting_queue_length > 5
+          for: 3m
+          labels:
+            severity: warning
+            priority: P1
+          annotations:
+            summary: "Judge waiting queue is backing up"
+            description: "More than 5 submissions are waiting because no judge-server was available."
+        - alert: CeleryWorkerRestarting
+          expr: sum(increase(kube_pod_container_status_restarts_total{pod=~"celery-worker-.*"}[15m])) > 3
+          labels:
+            severity: warning
+            priority: P1
+          annotations:
+            summary: "Celery worker is restarting repeatedly"
+            description: "Celery worker pods restarted more than 3 times in 15 minutes."
+        - alert: CeleryBeatDown
+          expr: min(kube_pod_status_ready{condition="true", pod=~"celery-beat-.*"}) == 0
+          for: 2m
+          labels:
+            severity: warning
+            priority: P1
+          annotations:
+            summary: "Celery beat is not ready"
+            description: "The celery-beat pod has not been ready for 2 minutes."
+        - alert: PodCrashLooping
+          expr: sum by (pod) (increase(kube_pod_container_status_restarts_total{pod=~"backend-.*|frontend-.*|celery-.*|judge-server-.*"}[5m])) > 0
+          for: 5m
+          labels:
+            severity: warning
+            priority: P1
+          annotations:
+            summary: "CodePlace pod is restarting"
+            description: "A CodePlace application pod has restarted within the last 5 minutes."
+        - alert: PVCAlmostFull
+          expr: kubelet_volume_stats_used_bytes / kubelet_volume_stats_capacity_bytes > 0.85
+          for: 10m
+          labels:
+            severity: warning
+            priority: P1
+          annotations:
+            summary: "PVC usage is above 85%"
+            description: "A persistent volume claim has been above 85% usage for 10 minutes."


### PR DESCRIPTION
#540 

# Changelog

- backend `/metrics` 및 custom Prometheus metrics 추가
- request JSON log, `X-Request-ID` 처리 추가
- OpenTelemetry 기본 비활성 상태로 계측 코드 추가
- Kubernetes용 `ServiceMonitor`, `PrometheusRule`, `AlertmanagerConfig`, Grafana dashboard 추가
- frontend nginx 로그를 stdout/stderr로 전환
- Swarm monitoring은 변경 없음

# Testing

- `python3 -m compileall backend/account backend/judge backend/oj backend/utils` 통과
- `manage.py check --settings=oj.settings` 통과
- `JSON_LOGGING=1` 상태 check 통과
- `/metrics` 200 및 custom metric 노출 확인
- `X-Request-ID` 응답 header 반환 확인
- `kubectl kustomize kubernetes/base` 통과

# Ops Impact

- DB 마이그레이션 없음
- `/metrics`는 cluster 내부 scrape 전용
- Discord 알림용 Secret 생성 필요
- 기존 kube-prometheus-stack/Grafana/Alertmanager에 붙는 방식
- OpenTelemetry는 기본 `OTEL_ENABLED=0`

# Version Compatibility

- 기존 API와 호환됨
- DB schema 변경 없음
- Prometheus Operator가 `ServiceMonitor`, `PrometheusRule`, `AlertmanagerConfig.discordConfigs`를 지원해야 함