### PR TITLE
#540 쿠버네티스 관측성 확보 후 후속 오류 수정 2

### DIFF
--- a/backend/utils/tests.py
+++ b/backend/utils/tests.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import pickle
 from unittest.mock import patch, mock_open, MagicMock
 from django.test import SimpleTestCase, TestCase, override_settings
 from django.core.cache import cache
@@ -10,6 +11,26 @@ from utils.json_logging import CodePlaceJsonFormatter
 from utils.observability_metrics import CodePlaceCollector
 from utils import observability_tracing
 from utils.testcase_cache import TestCaseCacheManager
+from utils.throttling import TokenBucket
+
+
+class TokenBucketTest(SimpleTestCase):
+
+    def test_reads_raw_byte_values(self):
+        redis_conn = MagicMock()
+        redis_conn.hget.side_effect = [b"7.0"]
+
+        bucket = TokenBucket("1", capacity=10, fill_rate=1, default_capacity=10, redis_conn=redis_conn)
+
+        self.assertEqual(bucket._last_capacity, 7.0)
+
+    def test_reads_pickled_byte_values_from_django_redis_hash(self):
+        redis_conn = MagicMock()
+        redis_conn.hget.side_effect = [pickle.dumps(7.0)]
+
+        bucket = TokenBucket("1", capacity=10, fill_rate=1, default_capacity=10, redis_conn=redis_conn)
+
+        self.assertEqual(bucket._last_capacity, 7.0)
 
 
 class CodePlaceCollectorTest(SimpleTestCase):

--- a/backend/utils/throttling.py
+++ b/backend/utils/throttling.py
@@ -1,4 +1,5 @@
 import time
+import pickle
 
 
 class TokenBucket:
@@ -22,6 +23,15 @@ class TokenBucket:
         self._last_capacity_key = "last_capacity"
         self._last_timestamp_key = "last_timestamp"
 
+    @staticmethod
+    def _as_float(value):
+        if isinstance(value, bytes):
+            try:
+                value = value.decode()
+            except UnicodeDecodeError:
+                value = pickle.loads(value)
+        return float(value)
+
     def _init_key(self):
         self._last_capacity = self._default_capacity
         now = time.time()
@@ -34,7 +44,7 @@ class TokenBucket:
         if last_capacity is None:
             return self._init_key()[0]
         else:
-            return float(last_capacity)
+            return self._as_float(last_capacity)
 
     @_last_capacity.setter
     def _last_capacity(self, value):
@@ -42,7 +52,7 @@ class TokenBucket:
 
     @property
     def _last_timestamp(self):
-        return float(self._redis_conn.hget(self._key, self._last_timestamp_key))
+        return self._as_float(self._redis_conn.hget(self._key, self._last_timestamp_key))
 
     @_last_timestamp.setter
     def _last_timestamp(self, value):

--- a/kubernetes/monitoring/grafana-dashboard-kubernetes-events.yaml
+++ b/kubernetes/monitoring/grafana-dashboard-kubernetes-events.yaml
@@ -191,7 +191,7 @@ data:
           "type": "logs",
           "title": "Kubernetes Warning Events",
           "gridPos": {"x": 0, "y": 12, "w": 24, "h": 9},
-          "datasource": "Loki",
+          "datasource": {"type": "loki", "uid": "Loki"},
           "options": {
             "showLabels": false,
             "showTime": true,
@@ -206,7 +206,7 @@ data:
           "type": "logs",
           "title": "Scheduling, Pull, Restart, and Probe Events",
           "gridPos": {"x": 0, "y": 21, "w": 24, "h": 9},
-          "datasource": "Loki",
+          "datasource": {"type": "loki", "uid": "Loki"},
           "options": {
             "showLabels": false,
             "showTime": true,

--- a/kubernetes/monitoring/grafana-dashboard-logs.yaml
+++ b/kubernetes/monitoring/grafana-dashboard-logs.yaml
@@ -106,7 +106,7 @@ data:
           "type": "stat",
           "title": "Log Lines",
           "gridPos": {"x": 12, "y": 0, "w": 4, "h": 4},
-          "datasource": "Loki",
+          "datasource": {"type": "loki", "uid": "Loki"},
           "fieldConfig": {"defaults": {"unit": "short"}},
           "options": {"reduceOptions": {"calcs": ["lastNotNull"], "values": false}},
           "targets": [
@@ -117,7 +117,7 @@ data:
           "type": "stat",
           "title": "Backend Errors",
           "gridPos": {"x": 16, "y": 0, "w": 4, "h": 4},
-          "datasource": "Loki",
+          "datasource": {"type": "loki", "uid": "Loki"},
           "fieldConfig": {
             "defaults": {
               "unit": "short",
@@ -140,7 +140,7 @@ data:
           "type": "stat",
           "title": "Frontend 5xx",
           "gridPos": {"x": 20, "y": 0, "w": 4, "h": 4},
-          "datasource": "Loki",
+          "datasource": {"type": "loki", "uid": "Loki"},
           "fieldConfig": {
             "defaults": {
               "unit": "short",
@@ -163,7 +163,7 @@ data:
           "type": "timeseries",
           "title": "Log Lines by Namespace",
           "gridPos": {"x": 0, "y": 4, "w": 8, "h": 7},
-          "datasource": "Loki",
+          "datasource": {"type": "loki", "uid": "Loki"},
           "fieldConfig": {"defaults": {"unit": "logs/sec"}},
           "targets": [
             {"expr": "sum by (namespace) (rate({namespace=~\"code-place-dev|code-place-prod|monitoring|kube-system\"}[5m]))", "legendFormat": "{{namespace}}"}
@@ -173,7 +173,7 @@ data:
           "type": "timeseries",
           "title": "Application Log Lines by App",
           "gridPos": {"x": 8, "y": 4, "w": 8, "h": 7},
-          "datasource": "Loki",
+          "datasource": {"type": "loki", "uid": "Loki"},
           "fieldConfig": {"defaults": {"unit": "logs/sec"}},
           "targets": [
             {"expr": "sum by (namespace, app) (rate({namespace=~\"code-place-dev|code-place-prod\", app=~\"backend|frontend\"}[5m]))", "legendFormat": "{{namespace}} {{app}}"},
@@ -184,7 +184,7 @@ data:
           "type": "timeseries",
           "title": "Structured Error Logs by Component",
           "gridPos": {"x": 16, "y": 4, "w": 8, "h": 7},
-          "datasource": "Loki",
+          "datasource": {"type": "loki", "uid": "Loki"},
           "fieldConfig": {"defaults": {"unit": "logs/sec"}},
           "targets": [
             {"expr": "sum by (namespace, app) (rate({namespace=~\"code-place-dev|code-place-prod\", app=~\"backend|frontend\"} | json | level=~\"ERROR|CRITICAL\" [5m]))", "legendFormat": "{{namespace}} {{app}}"},
@@ -195,7 +195,7 @@ data:
           "type": "stat",
           "title": "Ingress 5xx",
           "gridPos": {"x": 0, "y": 11, "w": 4, "h": 4},
-          "datasource": "Loki",
+          "datasource": {"type": "loki", "uid": "Loki"},
           "fieldConfig": {
             "defaults": {
               "unit": "short",
@@ -218,7 +218,7 @@ data:
           "type": "timeseries",
           "title": "Log Lines by Node",
           "gridPos": {"x": 0, "y": 15, "w": 4, "h": 6},
-          "datasource": "Loki",
+          "datasource": {"type": "loki", "uid": "Loki"},
           "fieldConfig": {"defaults": {"unit": "logs/sec"}},
           "targets": [
             {"expr": "sum by (node) (rate({namespace=~\"code-place-dev|code-place-prod|monitoring|kube-system\"}[5m]))", "legendFormat": "{{node}}"}
@@ -228,7 +228,7 @@ data:
           "type": "logs",
           "title": "Recent Backend Errors",
           "gridPos": {"x": 4, "y": 11, "w": 10, "h": 10},
-          "datasource": "Loki",
+          "datasource": {"type": "loki", "uid": "Loki"},
           "options": {
             "showLabels": false,
             "showTime": true,
@@ -243,7 +243,7 @@ data:
           "type": "logs",
           "title": "Auth, Judge, Celery, and vLLM Logs",
           "gridPos": {"x": 14, "y": 11, "w": 10, "h": 10},
-          "datasource": "Loki",
+          "datasource": {"type": "loki", "uid": "Loki"},
           "options": {
             "showLabels": false,
             "showTime": true,
@@ -258,7 +258,7 @@ data:
           "type": "logs",
           "title": "Ingress and Frontend 4xx/5xx Logs",
           "gridPos": {"x": 0, "y": 21, "w": 24, "h": 8},
-          "datasource": "Loki",
+          "datasource": {"type": "loki", "uid": "Loki"},
           "options": {
             "showLabels": false,
             "showTime": true,
@@ -274,7 +274,7 @@ data:
           "type": "logs",
           "title": "Request ID Lookup",
           "gridPos": {"x": 0, "y": 29, "w": 24, "h": 9},
-          "datasource": "Loki",
+          "datasource": {"type": "loki", "uid": "Loki"},
           "options": {
             "showLabels": false,
             "showTime": true,
@@ -289,7 +289,7 @@ data:
           "type": "logs",
           "title": "Frontend Runtime Error Reports",
           "gridPos": {"x": 0, "y": 38, "w": 24, "h": 8},
-          "datasource": "Loki",
+          "datasource": {"type": "loki", "uid": "Loki"},
           "options": {
             "showLabels": false,
             "showTime": true,


### PR DESCRIPTION
# Changelog

- Celery broker queue metric이 실제 Celery broker Redis DB를 조회하도록 수정했습니다.
- Discord alert 메시지를 한국어로 정리했습니다.
- Loki dashboard 패널이 Prometheus datasource로 잘못 질의하지 않도록 datasource UID를 고정했습니다.
- django-redis 7 HashMap 직렬화 변경으로 제출 throttling이 실패하던 문제를 수정했습니다.

# Testing

- `backend/manage.py test utils.tests --keepdb`

# Ops Impact

- DB 마이그레이션 없음.
- monitoring manifest 재적용 필요.
- backend 재배포 후 `/api/submission` throttling Redis 값 처리 오류가 해소됩니다.

# Version Compatibility

- django-redis 7.x의 hash value 직렬화 동작과 호환되도록 수정했습니다.