### PR TITLE
#540 서버 오류 응답 상태 코드 수정

### DIFF
--- a/backend/account/decorators.py
+++ b/backend/account/decorators.py
@@ -18,18 +18,19 @@ class BasePermissionDecorator(object):
     def __get__(self, obj, obj_type):
         return functools.partial(self.__call__, obj)
 
-    def error(self, data):
-        return JSONResponse.response({"error": "permission-denied", "data": data})
+    def error(self, data, status=403):
+        return JSONResponse.response({"error": "permission-denied", "data": data}, status=status)
 
     def __call__(self, *args, **kwargs):
         self.request = args[1]
 
         if self.check_permission():
             if self.request.user.is_disabled:
-                return self.error("Your account is disabled")
+                return self.error("Your account is disabled", status=403)
             return self.func(*args, **kwargs)
         else:
-            return self.error("Please login first")
+            status = 401 if not self.request.user.is_authenticated else 403
+            return self.error("Please login first", status=status)
 
     def check_permission(self):
         raise NotImplementedError()
@@ -212,7 +213,7 @@ class SchedulerOnlyDecorator(object):
         return JSONResponse.response({
             "error": "permission-denied",
             "data": "Scheduler token is invalid or missing",
-        })
+        }, status=403)
 
 
 def scheduler_only(view_func):

--- a/backend/account/middleware.py
+++ b/backend/account/middleware.py
@@ -134,7 +134,11 @@ class AdminRoleRequiredMiddleware(MiddlewareMixin):
         path = request.path_info
         if path.startswith("/admin/") or path.startswith("/api/admin/"):
             if not (request.user.is_authenticated and request.user.is_admin_role()):
-                return JSONResponse.response({"error": "login-required", "data": "Please login in first"})
+                status = 401 if not request.user.is_authenticated else 403
+                return JSONResponse.response(
+                    {"error": "login-required", "data": "Please login in first"},
+                    status=status,
+                )
 
 
 class LogSqlMiddleware(MiddlewareMixin):

--- a/backend/account/tests.py
+++ b/backend/account/tests.py
@@ -17,8 +17,8 @@ from utils.shortcuts import rand_str
 from options.options import SysOptions
 
 from .models import AdminType, ProblemPermission, User
-from .decorators import scheduler_only
-from .middleware import RequestIDMiddleware
+from .decorators import login_required, scheduler_only
+from .middleware import AdminRoleRequiredMiddleware, RequestIDMiddleware
 from .tasks import calculate_user_score_basis, calculate_user_score_fluctuation
 
 
@@ -65,6 +65,35 @@ class RequestIDMiddlewareTest(SimpleTestCase):
         self.assertEqual(response["X-Request-ID"], request.request_id)
 
 
+class AdminRoleRequiredMiddlewareTest(SimpleTestCase):
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_admin_api_requires_login_with_http_401(self):
+        middleware = AdminRoleRequiredMiddleware(lambda request: JsonResponse({"ok": True}))
+        request = self.factory.get("/api/admin/problem")
+        request.user = mock.MagicMock()
+        request.user.is_authenticated = False
+
+        response = middleware(request)
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.data, {"error": "login-required", "data": "Please login in first"})
+
+    def test_admin_api_requires_admin_role_with_http_403(self):
+        middleware = AdminRoleRequiredMiddleware(lambda request: JsonResponse({"ok": True}))
+        request = self.factory.get("/api/admin/problem")
+        request.user = mock.MagicMock()
+        request.user.is_authenticated = True
+        request.user.is_admin_role.return_value = False
+
+        response = middleware(request)
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.data, {"error": "login-required", "data": "Please login in first"})
+
+
 class PermissionDecoratorTest(APITestCase):
     """
     데코레이터 테스트
@@ -78,7 +107,18 @@ class PermissionDecoratorTest(APITestCase):
         self.request.user.is_authenticated = mock.MagicMock()
 
     def test_login_required(self):
-        self.request.user.is_authenticated.return_value = False
+        class TestAPIView(APIView):
+
+            @login_required
+            def get(self, request):
+                return self.success("Success")
+
+        self.request.user.is_authenticated = False
+
+        response = TestAPIView().get(self.request)
+
+        self.assertEqual(response.status_code, 401)
+        self.assertFailed(response, "Please login first")
 
     def test_admin_required(self):
         pass
@@ -106,6 +146,7 @@ class SchedulerOnlyDecoratorTest(APITestCase):
         """ Test when SCHEDULER_TOKEN is not set in the environment."""
         request = self.factory.post("/", HTTP_X_SCHEDULER_TOKEN='secret')
         response = self.view.post(request)
+        self.assertEqual(response.status_code, 403)
         self.assertFailed(response)
 
     def test_missing_header_token(self):
@@ -113,6 +154,7 @@ class SchedulerOnlyDecoratorTest(APITestCase):
         with mock.patch('os.environ', {}):
             request = self.factory.post("/")
             response = self.view.post(request)
+        self.assertEqual(response.status_code, 403)
         self.assertFailed(response)
 
     def test_valid_token(self):
@@ -127,6 +169,7 @@ class SchedulerOnlyDecoratorTest(APITestCase):
         with mock.patch('os.environ', {'SCHEDULER_TOKEN': 'secret'}):
             request = self.factory.post("/", HTTP_X_SCHEDULER_TOKEN='wrong_secret')
             response = self.view.post(request)
+        self.assertEqual(response.status_code, 403)
         self.assertFailed(response)
 
 

--- a/backend/utils/api/api.py
+++ b/backend/utils/api/api.py
@@ -61,8 +61,8 @@ class JSONResponse(object):
     content_type = ContentType.json_response
 
     @classmethod
-    def response(cls, data):
-        resp = HttpResponse(json.dumps(data, indent=4), content_type=cls.content_type)
+    def response(cls, data, status=200):
+        resp = HttpResponse(json.dumps(data, indent=4), content_type=cls.content_type, status=status)
         resp.data = data
         return resp
 
@@ -116,14 +116,14 @@ class APIView(View):
 
         return request.data
 
-    def response(self, data):
-        return self.response_class.response(data)
+    def response(self, data, status=200):
+        return self.response_class.response(data, status=status)
 
     def success(self, data=None):
         return self.response({"error": None, "data": data})
 
-    def error(self, msg="error", err="error"):
-        return self.response({"error": err, "data": msg})
+    def error(self, msg="error", err="error", status=400):
+        return self.response({"error": err, "data": msg}, status=status)
 
     def extract_errors(self, errors, key="field"):
         if isinstance(errors, dict):
@@ -145,7 +145,7 @@ class APIView(View):
         return self.error(err=f"invalid-{key}", msg=msg)
 
     def server_error(self):
-        return self.error(err="server-error", msg="server error")
+        return self.error(err="server-error", msg="server error", status=500)
 
     def paginate_data(self, request, query_set, object_serializer=None):
         """

--- a/backend/utils/tests.py
+++ b/backend/utils/tests.py
@@ -3,11 +3,12 @@ import logging
 import os
 import pickle
 from unittest.mock import patch, mock_open, MagicMock
-from django.test import SimpleTestCase, TestCase, override_settings
+from django.test import RequestFactory, SimpleTestCase, TestCase, override_settings
 from django.core.cache import cache
 from prometheus_client.core import GaugeMetricFamily
 
 from utils.json_logging import CodePlaceJsonFormatter
+from utils.api import APIView
 from utils.observability_metrics import CodePlaceCollector
 from utils import observability_tracing
 from utils.testcase_cache import TestCaseCacheManager
@@ -31,6 +32,36 @@ class TokenBucketTest(SimpleTestCase):
         bucket = TokenBucket("1", capacity=10, fill_rate=1, default_capacity=10, redis_conn=redis_conn)
 
         self.assertEqual(bucket._last_capacity, 7.0)
+
+
+class APIViewStatusCodeTest(SimpleTestCase):
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_server_exception_returns_http_500_with_existing_json_body(self):
+
+        class BrokenAPIView(APIView):
+
+            def get(self, request):
+                raise RuntimeError("boom")
+
+        response = BrokenAPIView.as_view()(self.factory.get("/"))
+
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.data, {"error": "server-error", "data": "server error"})
+
+    def test_business_error_returns_http_400(self):
+
+        class BusinessErrorAPIView(APIView):
+
+            def get(self, request):
+                return self.error(err="problem-not-found", msg="Problem not exist")
+
+        response = BusinessErrorAPIView.as_view()(self.factory.get("/"))
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data, {"error": "problem-not-found", "data": "Problem not exist"})
 
 
 class CodePlaceCollectorTest(SimpleTestCase):

--- a/frontend/src/pages/admin/api.js
+++ b/frontend/src/pages/admin/api.js
@@ -467,10 +467,16 @@ function ajax(url, method, options) {
           }
         }
       },
-      (res) => {
+      (error) => {
         // API请求异常，一般为Server error 或 network error
-        reject(res)
-        Vue.prototype.$error(res.data.data)
+        const res = error.response || error
+        const data = res.data || {}
+        const message = data.data || error.message || "Server error"
+        Vue.prototype.$error(message)
+        reject(error)
+        if (typeof message === "string" && message.startsWith("Please login")) {
+          router.push({ name: "login" })
+        }
       },
     )
   })

--- a/frontend/src/pages/oj/api.js
+++ b/frontend/src/pages/oj/api.js
@@ -514,10 +514,19 @@ function ajax(url, method, options) {
           // }
         }
       },
-      (res) => {
+      (error) => {
         // API请求异常，一般为Server error 或 network error
-        reject(res)
-        Vue.prototype.$error(res.data.data)
+        const res = error.response || error
+        const data = res.data || {}
+        const message = data.data || error.message || "Server error"
+        Vue.prototype.$error(message)
+        reject(error)
+        if (typeof message === "string" && message.startsWith("Please login")) {
+          store.dispatch("changeModalStatus", {
+            mode: "login",
+            visible: true,
+          })
+        }
       },
     )
   })


### PR DESCRIPTION
# Changelog

- API 오류 응답이 HTTP 200으로 내려가던 공통 경로를 정리했습니다.
- `APIView.error()`는 기본 HTTP 400, 내부 예외는 HTTP 500을 반환하도록 수정했습니다.
- 로그인 필요 응답은 401, 권한 없음/스케줄러 토큰 오류는 403을 반환하도록 수정했습니다.
- frontend OJ/Admin API wrapper가 4xx/5xx 응답에서도 기존 에러 메시지를 표시하도록 보완했습니다.
- 관련 회귀 테스트를 추가했습니다.

# Testing

- `backend/manage.py test utils.tests.APIViewStatusCodeTest account.tests.AdminRoleRequiredMiddlewareTest --keepdb`
- `node ./node_modules/.bin/eslint src/pages/oj/api.js src/pages/admin/api.js`

# Ops Impact

- DB 마이그레이션 없음.
- backend/frontend 재배포 필요.
- API 오류가 HTTP status code로도 드러나므로 Prometheus/Grafana 4xx/5xx 관측 정확도가 개선됩니다.

# Version Compatibility

- 응답 JSON 형식은 유지합니다.
- 오류 응답의 HTTP status code가 기존 200에서 400/401/403/500으로 변경됩니다.