### PR TITLE
2노드 클러스터 기준 설정 정리

### DIFF
--- a/kubernetes/base/redis/README.md
+++ b/kubernetes/base/redis/README.md
@@ -55,7 +55,8 @@ REDIS_SENTINEL_HOSTS=redis-sentinel:26379
 
 ## 운영 메모
 
-Redis와 Sentinel Pod는 `kubernetes.io/hostname` 기준으로 서로 다른 노드에 분산되도록 설정되어 있습니다. 이 구성은 최소 3개 이상의 스케줄 가능한 Kubernetes 노드를 전제로 합니다. 노드가 3개 미만이면 HA를 만족할 수 없으므로 Pod가 pending 상태로 남을 수 있습니다.
+Redis와 Sentinel Pod는 `kubernetes.io/hostname` 기준으로 분산되도록 설정되어 있습니다. 2노드 클러스터에서는 3개 Pod가 2/1 형태로 배치될 수 있으므로 `clusterSize: 3`, Sentinel `quorum: 2`, PDB `minAvailable: 2`를 유지합니다.
+다만 2노드에서는 3개 failure domain 기반의 완전한 HA가 아니며, 특정 노드 장애 시 Sentinel quorum 또는 failover 여력이 줄어들 수 있습니다.
 
 Sentinel failover는 Redis master 장애 시 자동 승격을 수행하지만, failover 중에는 짧은 연결 재시도 구간이 생길 수 있습니다. 완전한 무중단에 가깝게 운영하려면 Longhorn replica와 Kubernetes 노드 장애 조건이 맞는지, 애플리케이션 retry 정책이 충분한지 함께 점검해야 합니다.
 

--- a/kubernetes/monitoring/logs/README.md
+++ b/kubernetes/monitoring/logs/README.md
@@ -4,7 +4,7 @@ This directory contains Helm values for the Kubernetes logs stack.
 
 - Loki: SingleBinary mode, filesystem storage, Longhorn PVC.
 - Loki gateway: 2 replicas for the stateless write/query entrypoint.
-- Alloy: DaemonSet log collector for every pod in `code-place-dev`, `code-place-prod`, and `monitoring`, plus Traefik pods in `kube-system`. It mounts host `/var/log` so `/var/log/pods` is readable from the Alloy container. It tolerates the standard `control-plane` and `master` NoSchedule taints so the current three-node cluster does not silently miss logs from a tainted control-plane node.
+- Alloy: DaemonSet log collector for every pod in `code-place-dev`, `code-place-prod`, and `monitoring`, plus Traefik pods in `kube-system`. It mounts host `/var/log` so `/var/log/pods` is readable from the Alloy container. It tolerates the standard `control-plane` and `master` NoSchedule taints so tainted control-plane nodes are still covered.
 - Kubernetes Event Exporter: Warning events are written to stdout as JSON and collected by Alloy from the `monitoring` namespace.
 - Retention: `code-place-dev` 3 days, `code-place-prod` 7 days.
 - Monitoring: Loki and Alloy ServiceMonitors are enabled for kube-prometheus-stack.
@@ -80,7 +80,7 @@ Keep these invariants unless the storage design changes intentionally:
 - Loki stays in `SingleBinary` deployment mode.
 - Loki is installed from `grafana/loki` chart `6.55.0`. Do not upgrade the chart without revalidating rendered workloads and values compatibility.
 - Loki uses filesystem storage on a Longhorn PVC.
-- In the current three-node cluster, Alloy runs on every node. Loki and Tempo remain single-writer services on Longhorn PVCs, while stateless collectors, Loki gateway, and probe exporters can be replicated across nodes.
+- Alloy runs on every schedulable node. Loki and Tempo remain single-writer services on Longhorn PVCs, while stateless collectors, Loki gateway, and probe exporters can be replicated across nodes.
 - If a node uses a custom NoSchedule taint, add the matching Alloy toleration before relying on the `AlloyDaemonSetUnavailable` alert for full-node log coverage.
 - kube-prometheus-stack Prometheus and Alertmanager run with 2 replicas. Prometheus clears the replica external label so HA replicas do not create replica-labeled duplicate Alertmanager notifications. Prometheus, Alertmanager, and Grafana use Longhorn PVCs so metric data, silences, and UI state survive pod rescheduling.
 - Alloy keeps namespace-based collection for `code-place-dev`, `code-place-prod`, and `monitoring`; do not depend on `app.kubernetes.io/name` for CodePlace app logs because the application manifests primarily use `app`.

--- a/kubernetes/monitoring/prometheus-rules.yaml
+++ b/kubernetes/monitoring/prometheus-rules.yaml
@@ -383,23 +383,23 @@ spec:
             summary: "PostgreSQL metric 수집이 실패하고 있습니다"
             description: "CNPG PostgreSQL metric 수집 오류가 5분 동안 보고됐습니다."
         - alert: PostgresHADegraded
-          expr: min by (namespace) (cnpg_collector_nodes_used{namespace=~"code-place-(dev|prod)", cluster="postgres"}) < 3
+          expr: min by (namespace) (cnpg_collector_nodes_used{namespace=~"code-place-(dev|prod)", cluster="postgres"}) < 2
           for: 10m
           labels:
             severity: warning
             priority: P1
           annotations:
             summary: "PostgreSQL HA 배치가 저하됐습니다"
-            description: "CNPG가 10분 동안 PostgreSQL instance가 3개 미만의 노드에 배치됐다고 보고했습니다."
+            description: "CNPG가 10분 동안 PostgreSQL instance가 2개 미만의 노드에 배치됐다고 보고했습니다."
         - alert: PostgresReplicaUnavailable
-          expr: sum by (namespace) (kube_pod_status_ready{namespace=~"code-place-(dev|prod)", condition="true", pod=~"postgres-[0-9]+"}) < 3
+          expr: sum by (namespace) (kube_pod_status_ready{namespace=~"code-place-(dev|prod)", condition="true", pod=~"postgres-[0-9]+"}) < 2
           for: 5m
           labels:
             severity: warning
             priority: P1
           annotations:
             summary: "PostgreSQL ready replica 수가 부족합니다"
-            description: "PostgreSQL Pod ready 수가 5분 동안 3개 미만입니다. failover 여력이나 quorum이 줄어들 수 있습니다."
+            description: "PostgreSQL Pod ready 수가 5분 동안 2개 미만입니다. failover 여력이나 quorum이 줄어들 수 있습니다."
         - alert: RedisReplicaUnavailable
           expr: sum by (namespace) (kube_pod_status_ready{namespace=~"code-place-(dev|prod)", condition="true", pod=~"redis-.*|redis-replication-.*"}) < 6
           for: 5m

--- a/kubernetes/setup/longhorn/README.md
+++ b/kubernetes/setup/longhorn/README.md
@@ -88,6 +88,8 @@ kubectl get pods -n longhorn-system -w
 물리 노드가 3대 미만인 경우(예: 2대), 복제본을 배치할 공간이 부족하여 볼륨 상태가 Degraded로 표시될 수 있습니다.
 
 이 경우 Longhorn UI(Settings > General > Default Replica Count)에서 기본 복제본 수를 2로 변경해야 합니다.
+이미 생성된 기존 volume도 Longhorn UI(Volume > 각 volume > Number of Replicas)에서 2로 맞춰야 합니다.
+2노드 기준에서도 replica count가 2로 맞으면 volume은 정상 상태여야 하며, `LonghornVolumeDegraded` alert는 storage 설정 불일치나 실제 replica 장애를 잡는 신호로 유지합니다.
 
 ### 5. Monitoring
 


### PR DESCRIPTION
# Changelog

- 2노드 클러스터 기준으로 PostgreSQL HA 관련 알림 임계값을 조정했습니다.
- Longhorn 기본/기존 volume replica count를 2로 맞춰야 한다는 운영 문서를 보강했습니다.
- Redis/Sentinel은 기존 3 pod/quorum 2 구성을 유지하되, 2노드 운영 시 HA 한계를 문서에 명확히 정리했습니다.
- 로그 스택 문서에서 3노드 전제 표현을 제거했습니다.

# Testing

- `kubectl kustomize kubernetes/overlays/dev`
- `kubectl kustomize kubernetes/overlays/prod`
- `kubectl kustomize kubernetes/monitoring`

# Ops Impact

- DB 마이그레이션 없음.
- 애플리케이션 재배포 없음.
- PrometheusRule 적용 시 PostgreSQL HA/replica 부족 알림 기준이 2노드 운영 기준으로 변경됩니다.
- Longhorn volume replica count는 운영 환경에서 별도로 2로 맞춰야 합니다.

# Version Compatibility

- API/DB 스키마 변경 없음.
- Kubernetes 모니터링 설정 및 운영 문서 변경만 포함합니다.