### PR TITLE
문제 가져오기에서 필드(문제 영역) 5 허용 설정

### DIFF
--- a/backend/problem/serializers.py
+++ b/backend/problem/serializers.py
@@ -292,7 +292,7 @@ class ImportProblemSerializer(serializers.Serializer):
     spj = SPJSerializer(allow_null=True)
     rule_type = serializers.ChoiceField(choices=ProblemRuleType.choices())
     source = serializers.CharField(max_length=200, allow_blank=True, allow_null=True)
-    field = serializers.IntegerField(min_value=0, max_value=4)
+    field = serializers.IntegerField(min_value=0, max_value=5)
     difficulty = serializers.ChoiceField(choices=Difficulty.choices())
     answers = serializers.ListField(child=AnswerSerializer())
     tags = serializers.ListField(child=serializers.CharField())


### PR DESCRIPTION
# Changelog

- 문제 가져오기(beta)에서 `field: 5`인 문제를 가져올 수 있도록 허용 범위를 수정했습니다.
- 문제 생성과 문제 가져오기의 `field` 검증 범위를 `0~5`로 맞췄습니다.

# Testing

- 기존 오류: `field` 값이 5일 때 `max_value=4` 검증 실패
- 변경 후: `field` 값 5 허용

# Ops Impact

N/A

# Version Compatibility

N/A