### PR TITLE
#713 커뮤니티 게시글 미리보기 저장형 XSS 취약점 수정

### DIFF
--- a/backend/community/serializers.py
+++ b/backend/community/serializers.py
@@ -1,6 +1,7 @@
 from account.models import User
 from community.models import Comment, Post
 from contest.models import Contest
+from django.utils.html import strip_tags
 from problem.models import Problem
 from rest_framework import serializers
 
@@ -78,8 +79,9 @@ class PostListSerializer(serializers.ModelSerializer):
         ]
 
     def get_content_preview(self, obj):
-        """게시글 내용의 미리보기(처음 100자)를 반환합니다."""
-        return obj.content[:100] + ("..." if len(obj.content) > 100 else "")
+        """게시글 내용의 미리보기(HTML 태그를 제거한 처음 100자)를 반환합니다."""
+        text = strip_tags(obj.content)
+        return text[:100] + ("..." if len(text) > 100 else "")
 
     def get_community_type(self, obj):
         """게시글이 속한 커뮤니티 유형을 반환합니다."""

--- a/frontend/src/pages/oj/views/community/Community.vue
+++ b/frontend/src/pages/oj/views/community/Community.vue
@@ -155,8 +155,7 @@
                   <div
                     v-if="post.content_preview"
                     class="post-preview"
-                    v-html="post.content_preview"
-                  ></div>
+                  >{{ post.content_preview }}</div>
                 </div>
 
                 <div class="card-footer">

--- a/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/ProblemCommunity.vue
+++ b/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/ProblemCommunity.vue
@@ -107,8 +107,7 @@
         <div
           v-if="post.content_preview"
           class="post-preview"
-          v-html="post.content_preview"
-        ></div>
+        >{{ post.content_preview }}</div>
         <div class="post-footer">
           <div class="author-info">
             <img


### PR DESCRIPTION
# Changelog

- 커뮤니티 게시글 미리보기(`content_preview`)의 저장형 XSS 취약점 수정
  - 백엔드: `content_preview`를 `strip_tags`로 태그 제거 후 100자 반환
    (`backend/community/serializers.py`) — XSS 원천 차단, HTML 글자까지
    세어 100자를 자르던 버그도 함께 해결
  - 프론트: 목록/문제풀이 커뮤니티 탭 미리보기를 `v-html` → 텍스트 보간
    (`{{ }}`)으로 변경 (`Community.vue`, `ProblemCommunity.vue`) — 싱크 제거
- 상세 보기(Tiptap)는 기존에도 안전하여 변경 없음

# Testing
기존
<img width="1788" height="1134" alt="image" src="https://github.com/user-attachments/assets/2121a198-095c-483f-b829-6fa5601e6081" />
수정 후
<img width="1728" height="1052" alt="image" src="https://github.com/user-attachments/assets/4f04c814-04da-417a-8286-b23b0c790e77" />

<!-- 테스트 방법과 결과를 상세히 기술해주세요. -->
<!-- 단위 테스트, 통합 테스트 결과나 수동 테스트 내용을 포함해주세요. -->
<!-- 스크린샷이나 로그도 첨부하면 좋습니다. -->

# Ops Impact
N/A
<!-- 이 변경사항이 운영에 미치는 영향을 설명해주세요. -->
<!-- 서버 재시작이 필요한지, DB 마이그레이션이 있는지, 성능에 영향을 주는지 등 운영팀이 알아야 할 사항을 기재해주세요. -->
<!-- 해당 사항이 없다면 N/A로 기재해주세요. -->

# Version Compatibility
N/A
<!-- 이 변경사항이 기존 버전과의 호환성에 영향을 주는지 설명해주세요. -->
<!-- 하위/상위 버전 호환성 이슈가 있는지, 클라이언트/서버 버전 동기화가 필요한지 등을 기재해주세요. -->
<!-- 해당 사항이 없다면 N/A로 기재해주세요. -->
