### PR TITLE
문제 풀이 AI 조교 패널 레이아웃 수정

### DIFF
--- a/frontend/src/pages/oj/views/problem/problemSolving/Problem.vue
+++ b/frontend/src/pages/oj/views/problem/problemSolving/Problem.vue
@@ -82,14 +82,17 @@
             :submissionId="submissionId"
             :isSubmitting="submitting"
           />
-          <CodeEditor
-            :value.sync="code"
-            :languages="problem.languages"
-            :language="language"
-            :cursorPos.sync="cursorPos"
-            :allowPaste="allowPaste"
-            ref="myCm"
-          />
+          <div class="code-editor-area">
+            <CodeEditor
+              :value.sync="code"
+              :languages="problem.languages"
+              :language="language"
+              :cursorPos.sync="cursorPos"
+              :allowPaste="allowPaste"
+              ref="myCm"
+            />
+            <StickyLnCol :cursorPos="cursorPos" />
+          </div>
           <BottomDrag
             ref="bottomDrag"
             :result="result"
@@ -97,7 +100,6 @@
             :contestID="contestID"
             :code="code"
           />
-          <StickyLnCol :cursorPos="cursorPos" />
         </div>
       </pane>
     </splitpanes>
@@ -763,6 +765,20 @@ export default {
 .editor-pane-wrapper {
   position: relative;
   height: 100%;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.editor-pane-wrapper > .container-header {
+  flex: 0 0 auto;
+}
+
+.code-editor-area {
+  position: relative;
+  display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 .tab-headers {

--- a/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/BottomDrag.vue
+++ b/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/BottomDrag.vue
@@ -248,15 +248,21 @@ export default {
     onMouseMove(e) {
       if (!this.isDragging) return
       const parentRect = this.$el.parentElement.getBoundingClientRect()
+      const editorArea = this.$el.parentElement.querySelector(".code-editor-area")
+      const editorAreaTop = editorArea
+        ? editorArea.getBoundingClientRect().top
+        : parentRect.top
       const minPanelHeight = 120
       const minEditorHeight = 220
       const newHeight = parentRect.bottom - e.clientY
-      if (
-        newHeight > minPanelHeight &&
-        newHeight < parentRect.height - minEditorHeight
-      ) {
-        this.$el.style.height = `${newHeight}px`
-      }
+      const maxPanelHeight = parentRect.bottom - editorAreaTop - minEditorHeight
+      if (maxPanelHeight < minPanelHeight) return
+
+      const nextHeight = Math.min(
+        Math.max(newHeight, minPanelHeight),
+        maxPanelHeight,
+      )
+      this.$el.style.height = `${nextHeight}px`
     },
     onMouseUp() {
       this.isDragging = false

--- a/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/BottomDrag.vue
+++ b/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/BottomDrag.vue
@@ -248,8 +248,13 @@ export default {
     onMouseMove(e) {
       if (!this.isDragging) return
       const parentRect = this.$el.parentElement.getBoundingClientRect()
+      const minPanelHeight = 120
+      const minEditorHeight = 220
       const newHeight = parentRect.bottom - e.clientY
-      if (newHeight > 120 && newHeight < parentRect.height - 60) {
+      if (
+        newHeight > minPanelHeight &&
+        newHeight < parentRect.height - minEditorHeight
+      ) {
         this.$el.style.height = `${newHeight}px`
       }
     },
@@ -291,13 +296,11 @@ export default {
 <style scoped>
 /* 기존 스타일 그대로 유지 (생략 없이 사용하세요) */
 .editor-container {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
+  position: relative;
   height: 260px;
   display: flex;
   flex-direction: column;
+  flex: 0 0 auto;
   z-index: 10;
 }
 

--- a/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/CodeEditor.vue
+++ b/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/CodeEditor.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="code-editor-wrapper">
     <codemirror
       ref="myCm"
       :value="value"
@@ -204,10 +204,19 @@ export default {
 </script>
 
 <style>
-.CodeMirror {
-  height: calc(100vh - 132px) !important;
+.code-editor-wrapper .CodeMirror {
+  height: 100% !important;
   border-radius: 7px;
   border: 1px solid var(--border-color);
+}
+
+.code-editor-wrapper {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.code-editor-wrapper .vue-codemirror {
+  height: 100%;
 }
 
 .cm-s-ayu-mirage .CodeMirror-matchingbracket {

--- a/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/CodeEditor.vue
+++ b/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/CodeEditor.vue
@@ -108,6 +108,9 @@ export default {
     onCmReady() {},
     onCmCodeChange(newCode) {
       this.$emit("update:value", newCode)
+      this.emitCursorPos()
+    },
+    emitCursorPos() {
       this.$emit("update:cursorPos", {
         ln: this.codemirror.doc.getCursor().line,
         ch: this.codemirror.doc.getCursor().ch,
@@ -172,6 +175,7 @@ export default {
     this.codemirror.setOption("theme", customTheme)
 
     this.code = this.value
+    this.codemirror.on("cursorActivity", this.emitCursorPos)
 
     utils.getLanguages().then((languages) => {
       let mode = {}
@@ -186,10 +190,12 @@ export default {
     if (checkContest) {
       this.blockPasteFromExternalSource()
     }
-    this.$emit("update:cursorPos", {
-      ln: this.codemirror.doc.getCursor().line,
-      ch: this.codemirror.doc.getCursor().ch,
-    })
+    this.emitCursorPos()
+  },
+  beforeDestroy() {
+    if (this.codemirror) {
+      this.codemirror.off("cursorActivity", this.emitCursorPos)
+    }
   },
   watch: {
     isDarkMode(value) {

--- a/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/StickyLnCol.vue
+++ b/frontend/src/pages/oj/views/problem/problemSolving/problemSolvingComponent/StickyLnCol.vue
@@ -14,9 +14,10 @@ export default defineComponent({
 
 <style lang="less">
 .sticky_ln_col {
-  position: sticky;
-  float: right;
-  right: 10px;
-  bottom: 20px;
+  position: absolute;
+  right: 28px;
+  bottom: 14px;
+  z-index: 11;
+  pointer-events: none;
 }
 </style>


### PR DESCRIPTION
# Changelog

- AI 조교 패널이 코드 에디터를 가리지 않도록 문제 풀이 화면 레이아웃을 수정했습니다.
- `Ln/Col` 표시 위치와 갱신 방식을 개선했습니다.

<img width="1912" height="1181" alt="Screenshot 2026-06-26 at 4 33 52 pm" src="https://github.com/user-attachments/assets/105d5462-b761-4d40-a107-17db92f3f1a1" />

# Testing

- `/problem/1000`에서 AI 조교 패널 열림/드래그 동작을 수동 확인했습니다.
- 입력, 클릭, 방향키 이동 시 `Ln/Col` 표시가 갱신되는 것을 확인했습니다.
- 프론트 dev 서버에서 컴파일 성공을 확인했습니다.

# Ops Impact

N/A

# Version Compatibility

N/A