### PR TITLE
#668 문제 목록 태그 숨김 토글 추가 및 정렬 기능 추가

### DIFF
--- a/backend/problem/tests.py
+++ b/backend/problem/tests.py
@@ -241,6 +241,90 @@ class ProblemAPITest(ProblemCreateTestBase):
         resp = self.client.get(f"{self.url}?limit=10")
         self.assertSuccess(resp)
 
+    def test_get_problem_list_sort_by_accepted_number(self):
+        self.problem.accepted_number = 2
+        self.problem.submission_number = 10
+        self.problem.save(update_fields=["accepted_number", "submission_number"])
+        more_accepted_problem = self.create_problem_with_custom_field(
+            self.problem.created_by,
+            _id="A-111",
+            title="accepted sort target",
+            accepted_number=5,
+            submission_number=8,
+        )
+
+        resp = self.client.get(f"{self.url}?limit=10&sort=accepted_desc")
+
+        self.assertSuccess(resp)
+        results = resp.data["data"]["results"]
+        self.assertEqual(results[0]["_id"], more_accepted_problem._id)
+
+        resp = self.client.get(f"{self.url}?limit=10&sort=accepted_asc")
+
+        self.assertSuccess(resp)
+        results = resp.data["data"]["results"]
+        self.assertEqual(results[0]["_id"], self.problem._id)
+
+    def test_get_problem_list_sort_by_ac_rate(self):
+        self.problem.accepted_number = 0
+        self.problem.submission_number = 0
+        self.problem.save(update_fields=["accepted_number", "submission_number"])
+        higher_rate_problem = self.create_problem_with_custom_field(
+            self.problem.created_by,
+            _id="A-112",
+            title="rate sort target",
+            accepted_number=3,
+            submission_number=4,
+        )
+        lower_rate_problem = self.create_problem_with_custom_field(
+            self.problem.created_by,
+            _id="A-113",
+            title="lower rate sort target",
+            accepted_number=1,
+            submission_number=10,
+        )
+
+        resp = self.client.get(f"{self.url}?limit=10&sort=ac_rate_desc")
+
+        self.assertSuccess(resp)
+        results = resp.data["data"]["results"]
+        self.assertEqual(results[0]["_id"], higher_rate_problem._id)
+
+        resp = self.client.get(f"{self.url}?limit=10&sort=ac_rate_asc")
+
+        self.assertSuccess(resp)
+        results = resp.data["data"]["results"]
+        self.assertEqual(results[0]["_id"], self.problem._id)
+        self.assertEqual(results[1]["_id"], lower_rate_problem._id)
+
+    def test_get_problem_list_sort_by_difficulty(self):
+        self.problem.difficulty = Difficulty.MID
+        self.problem.save(update_fields=["difficulty"])
+        low_problem = self.create_problem_with_custom_field(
+            self.problem.created_by,
+            _id="A-114",
+            title="low difficulty sort target",
+            difficulty=Difficulty.LOW,
+        )
+        very_high_problem = self.create_problem_with_custom_field(
+            self.problem.created_by,
+            _id="A-115",
+            title="very high difficulty sort target",
+            difficulty=Difficulty.VERYHIGH,
+        )
+
+        resp = self.client.get(f"{self.url}?limit=10&sort=difficulty_asc")
+
+        self.assertSuccess(resp)
+        results = resp.data["data"]["results"]
+        self.assertEqual(results[0]["_id"], low_problem._id)
+
+        resp = self.client.get(f"{self.url}?limit=10&sort=difficulty_desc")
+
+        self.assertSuccess(resp)
+        results = resp.data["data"]["results"]
+        self.assertEqual(results[0]["_id"], very_high_problem._id)
+
     def test_get_one_problem(self):
         resp = self.client.get(self.url + "?problem_id=" + self.problem._id)
         self.assertSuccess(resp)

--- a/backend/problem/views/oj.py
+++ b/backend/problem/views/oj.py
@@ -3,7 +3,7 @@ import random
 import json
 
 from django.db import transaction
-from django.db.models import Count, F, Q
+from django.db.models import Case, Count, ExpressionWrapper, F, FloatField, IntegerField, Q, Value, When
 from django.http import HttpResponseBadRequest, HttpResponseNotFound, StreamingHttpResponse
 from django.contrib.auth import get_user_model
 
@@ -83,6 +83,22 @@ class BonusProblemAPI(APIView):
 
 
 class ProblemAPI(APIView):
+    DIFFICULTY_ORDER = {
+        Difficulty.VERYLOW: 1,
+        Difficulty.LOW: 2,
+        Difficulty.MID: 3,
+        Difficulty.HIGH: 4,
+        Difficulty.VERYHIGH: 5,
+    }
+
+    SORT_FIELDS = {
+        "difficulty_asc": ("difficulty_order", "_id"),
+        "difficulty_desc": ("-difficulty_order", "_id"),
+        "accepted_desc": ("-accepted_number", "_id"),
+        "accepted_asc": ("accepted_number", "_id"),
+        "ac_rate_desc": ("-ac_rate", "_id"),
+        "ac_rate_asc": ("ac_rate", "_id"),
+    }
 
     @staticmethod
     def _add_problem_status(request, queryset_values):
@@ -142,6 +158,27 @@ class ProblemAPI(APIView):
         field = request.GET.get("field")
         if field:
             problems = problems.filter(field=field)
+
+        sort = request.GET.get("sort")
+        if sort in self.SORT_FIELDS:
+            problems = problems.annotate(
+                difficulty_order=Case(
+                    *[
+                        When(difficulty=difficulty, then=Value(order))
+                        for difficulty, order in self.DIFFICULTY_ORDER.items()
+                    ],
+                    default=Value(0),
+                    output_field=IntegerField(),
+                ),
+                ac_rate=Case(
+                    When(submission_number=0, then=Value(0.0)),
+                    default=ExpressionWrapper(
+                        F("accepted_number") * 1.0 / F("submission_number"),
+                        output_field=FloatField(),
+                    ),
+                    output_field=FloatField(),
+                ),
+            ).order_by(*self.SORT_FIELDS[sort])
 
         # 根据profile 为做过的题目添加标记
         data = self.paginate_data(request, problems, ProblemSerializer)

--- a/frontend/src/i18n/oj/en-US.js
+++ b/frontend/src/i18n/oj/en-US.js
@@ -293,6 +293,8 @@ export const m = {
   Reset: "새로고침",
   Pick_One: "문제 랜덤 선택",
   Search_Problem: "문제 제목 / 번호 검색",
+  Hide_Tags: "태그 숨김",
+  Show_Tags: "태그 표시",
   // ProblemListTable.vue
   noProblemList: "찾으시는 문제가 존재하지 않습니다.",
   Th_Problem_Id: "문제번호",

--- a/frontend/src/i18n/oj/zh-CN.js
+++ b/frontend/src/i18n/oj/zh-CN.js
@@ -211,6 +211,8 @@ export const m = {
   All: "全部",
   Reset: "重置",
   Pick_One: "选择",
+  Hide_Tags: "隐藏标签",
+  Show_Tags: "显示标签",
   Difficulty: "难度",
   Total: "总数",
   AC_Rate: "通过率",

--- a/frontend/src/i18n/oj/zh-TW.js
+++ b/frontend/src/i18n/oj/zh-TW.js
@@ -212,6 +212,8 @@ export const m = {
   All: "全部",
   Reset: "重置",
   Pick_One: "選擇",
+  Hide_Tags: "隱藏標籤",
+  Show_Tags: "顯示標籤",
   Difficulty: "難度",
   Total: "總數",
   AC_Rate: "通過率",

--- a/frontend/src/pages/oj/components/Pagination.vue
+++ b/frontend/src/pages/oj/components/Pagination.vue
@@ -6,7 +6,7 @@
       @on-change="onChange"
       @on-page-size-change="onPageSizeChange"
       :show-sizer="showSizer"
-      :page-size-opts="[10, 30, 50, 100, 200]"
+      :page-size-opts="pageSizeOpts"
       :current="current"
     ></Page>
   </div>
@@ -32,6 +32,11 @@ export default {
     current: {
       required: false,
       type: Number,
+    },
+    pageSizeOpts: {
+      required: false,
+      type: Array,
+      default: () => [10, 30, 50, 100, 200],
     },
   },
   methods: {

--- a/frontend/src/pages/oj/views/problem/problemList/ProblemList.vue
+++ b/frontend/src/pages/oj/views/problem/problemList/ProblemList.vue
@@ -8,11 +8,18 @@
           @update-query="updateQuery"
           @pick-one="pickOne"
         />
-        <ProblemListTable :problemList="problemList" @select-tag="filterByTag" />
+        <ProblemListTable
+          :problemList="problemList"
+          :showTags="!isTagHidden"
+          :sort="query.sort"
+          @sort-change="sortProblems"
+          @select-tag="filterByTag"
+        />
         <Pagination
           :total="total"
           :page-size.sync="query.limit"
           :current.sync="query.page"
+          :page-size-opts="[15, 30, 50, 100, 200]"
           @on-change="pushRouter"
           @on-page-size-change="pushRouter"
           :show-sizer="true"
@@ -21,8 +28,8 @@
       </div>
       <keep-alive>
         <div class="right-container">
-          <MostDifficultProblemLastWeekBox />
-          <PersonalRecommendationBox />
+          <MostDifficultProblemLastWeekBox :showTags="!isTagHidden" />
+          <PersonalRecommendationBox :showTags="!isTagHidden" />
         </div>
       </keep-alive>
     </div>
@@ -83,8 +90,10 @@ export default {
         field: "",
         category: "",
         tag: "",
+        hideTag: "",
+        sort: "",
         page: 1,
-        limit: 10,
+        limit: 15,
       },
     }
   },
@@ -100,11 +109,13 @@ export default {
       this.query.keyword = query.keyword || ""
       this.query.field = query.field || ""
       this.query.tag = query.tag || ""
+      this.query.hideTag = query.hideTag === "1" ? "1" : ""
+      this.query.sort = query.sort || ""
       this.query.page = parseInt(query.page) || 1
       if (this.query.page < 1) {
         this.query.page = 1
       }
-      this.query.limit = parseInt(query.limit) || 10
+      this.query.limit = parseInt(query.limit) || 15
       if (!simulate) {
         this.getTagList()
       }
@@ -126,7 +137,7 @@ export default {
     async getProblemList() {
       let offset = (this.query.page - 1) * this.query.limit
       this.loadings.table = true
-      await api.getProblemList(offset, this.limit, this.query).then(
+      await api.getProblemList(offset, this.query.limit, this.query).then(
         (res) => {
           this.loadings.table = false
           this.total = res.data.data.total
@@ -162,6 +173,9 @@ export default {
     filterByTag(tag) {
       this.updateQuery({ tag, page: 1 })
     },
+    sortProblems(sort) {
+      this.updateQuery({ sort, page: 1 })
+    },
   },
   computed: {
     ...mapGetters([
@@ -171,6 +185,9 @@ export default {
       "isAuthenticated",
       "isAdminRole",
     ]),
+    isTagHidden() {
+      return this.query.hideTag === "1"
+    },
   },
   watch: {
     $route(newVal, oldVal) {

--- a/frontend/src/pages/oj/views/problem/problemList/problemListComponent/ProblemListTable.vue
+++ b/frontend/src/pages/oj/views/problem/problemList/problemListComponent/ProblemListTable.vue
@@ -4,9 +4,36 @@
       <tr>
         <th class="th-first">{{ $t("m.Th_Problem_Id") }}</th>
         <th class="th-second">{{ $t("m.Th_Problem_Title") }}</th>
-        <th class="th-third">{{ $t("m.Th_Problem_Difficulty") }}</th>
-        <th class="th-fourth">{{ $t("m.Th_Problem_Num_Success") }}</th>
-        <th class="th-fifth">{{ $t("m.Th_Problem_AC_Rate") }}</th>
+        <th class="th-third">
+          <button
+            type="button"
+            class="sort-header-button"
+            @click="changeSort('difficulty')"
+          >
+            {{ $t("m.Th_Problem_Difficulty") }}
+            <i :class="sortIconClass('difficulty')"></i>
+          </button>
+        </th>
+        <th class="th-fourth">
+          <button
+            type="button"
+            class="sort-header-button"
+            @click="changeSort('accepted')"
+          >
+            {{ $t("m.Th_Problem_Num_Success") }}
+            <i :class="sortIconClass('accepted')"></i>
+          </button>
+        </th>
+        <th class="th-fifth">
+          <button
+            type="button"
+            class="sort-header-button"
+            @click="changeSort('ac_rate')"
+          >
+            {{ $t("m.Th_Problem_AC_Rate") }}
+            <i :class="sortIconClass('ac_rate')"></i>
+          </button>
+        </th>
       </tr>
     </thead>
     <template v-if="this.problemList.length !== 0">
@@ -21,7 +48,7 @@
               {{ problem.title }}
             </span>
             <br />
-            <div class="problem-meta-row">
+            <div v-if="showTags" class="problem-meta-row">
               <FieldCategoryBox
                 :boxType="true"
                 :value="FIELD_MAP[problem.field].value"
@@ -83,6 +110,14 @@ export default {
       type: Array,
       default: () => [],
     },
+    showTags: {
+      type: Boolean,
+      default: true,
+    },
+    sort: {
+      type: String,
+      default: "",
+    },
   },
   methods: {
     ...mapActions(["changeProblemSolvingState"]),
@@ -98,6 +133,29 @@ export default {
     },
     getProblemTags(problem) {
       return Array.isArray(problem.tags) ? problem.tags : []
+    },
+    changeSort(field) {
+      const defaultDirection = field === "difficulty" ? "asc" : "desc"
+      const ascSort = `${field}_asc`
+      const descSort = `${field}_desc`
+      const defaultSort = `${field}_${defaultDirection}`
+      const reverseSort = defaultDirection === "asc" ? descSort : ascSort
+      const nextSort =
+        this.sort === defaultSort
+          ? reverseSort
+          : this.sort === reverseSort
+            ? ""
+            : defaultSort
+      this.$emit("sort-change", nextSort)
+    },
+    sortIconClass(field) {
+      if (this.sort === `${field}_asc`) {
+        return "fas fa-sort-up active"
+      }
+      if (this.sort === `${field}_desc`) {
+        return "fas fa-sort-down active"
+      }
+      return "fas fa-sort"
     },
   },
   computed: {
@@ -146,6 +204,30 @@ table:hover {
 
 th {
   font-size: 1.3em;
+}
+
+.sort-header-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  padding: 0;
+  color: inherit;
+  font: inherit;
+  font-weight: bold;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+}
+
+.sort-header-button i {
+  color: #a5adba;
+  font-size: 11px;
+}
+
+.sort-header-button i.active,
+.sort-header-button:hover i {
+  color: #4a86c0;
 }
 
 th:first-child {
@@ -230,8 +312,7 @@ td:nth-child(2) {
   cursor: pointer;
 }
 
-//.difficulty-badge {
-//  border-radius: 5px;
-//  border: 2px solid #dedede;
-//}
+.difficulty-badge {
+  white-space: nowrap;
+}
 </style>

--- a/frontend/src/pages/oj/views/problem/problemList/problemListComponent/ProblemListTable.vue
+++ b/frontend/src/pages/oj/views/problem/problemList/problemListComponent/ProblemListTable.vue
@@ -215,6 +215,7 @@ th {
   color: inherit;
   font: inherit;
   font-weight: bold;
+  white-space: nowrap;
   background: transparent;
   border: 0;
   cursor: pointer;

--- a/frontend/src/pages/oj/views/problem/problemList/problemListComponent/ProblemListTableHeader.vue
+++ b/frontend/src/pages/oj/views/problem/problemList/problemListComponent/ProblemListTableHeader.vue
@@ -1,7 +1,21 @@
 <template>
   <div class="problemListTableHeader">
-    <h1 class="main-title">{{ $t("m.Problem_List") }}</h1>
-    <div style="display: flex; align-items: center; justify-content: center">
+    <div class="header-title-row">
+      <h1 class="main-title">{{ $t("m.Problem_List") }}</h1>
+      <button
+        type="button"
+        class="tag-visibility-toggle"
+        :class="{ active: isTagHidden }"
+        :aria-pressed="isTagHidden ? 'true' : 'false'"
+        @click="toggleTagVisibility"
+      >
+        <i :class="isTagHidden ? 'fas fa-eye' : 'fas fa-eye-slash'"></i>
+        <span>{{
+          isTagHidden ? $t("m.Show_Tags") : $t("m.Hide_Tags")
+        }}</span>
+      </button>
+    </div>
+    <div class="header-controls">
       <li style="list-style-type: none; margin-left: 3px">
         <Input
           v-model="localKeyword"
@@ -140,6 +154,11 @@ export default {
     pickOne() {
       this.$emit("pick-one")
     },
+    toggleTagVisibility() {
+      this.$emit("update-query", {
+        hideTag: this.isTagHidden ? "" : "1",
+      })
+    },
   },
   computed: {
     DIFFICULTY_MAP() {
@@ -155,6 +174,9 @@ export default {
         .filter(Boolean)
       return Array.from(new Set(tags)).sort((a, b) => a.localeCompare(b))
     },
+    isTagHidden() {
+      return this.query.hideTag === "1"
+    },
   },
 }
 </script>
@@ -166,6 +188,26 @@ export default {
   margin-bottom: 25px;
   align-items: center;
   justify-content: space-between;
+  gap: 16px;
+
+  .header-title-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-shrink: 0;
+  }
+
+  .main-title {
+    margin: 0;
+  }
+
+  .header-controls {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+    gap: 5px;
+  }
 
   p {
     font-weight: bold;
@@ -183,10 +225,6 @@ export default {
     border: 1px solid #dedede;
     display: flex;
     align-items: center;
-  }
-
-  .dropdown:not(:first-child) {
-    margin-left: 5px;
   }
 
   .difficultyDropdown {
@@ -214,5 +252,30 @@ export default {
     text-overflow: ellipsis;
     white-space: nowrap;
   }
+
+  .tag-visibility-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: #8a93a5;
+    cursor: pointer;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1;
+    white-space: nowrap;
+  }
+
+  .tag-visibility-toggle i {
+    font-size: 12px;
+  }
+
+  .tag-visibility-toggle:hover,
+  .tag-visibility-toggle.active {
+    color: #344360;
+  }
+
 }
 </style>

--- a/frontend/src/pages/oj/views/problem/problemList/rightSideComponent/MostDifficultProblemLastWeekBox.vue
+++ b/frontend/src/pages/oj/views/problem/problemList/rightSideComponent/MostDifficultProblemLastWeekBox.vue
@@ -8,7 +8,7 @@
     </div>
     <div class="hardProblemRecommendationBoxBody">
       <template v-if="problem">
-        <div class="hardProblemFieldCategory">
+        <div v-if="showTags" class="hardProblemFieldCategory">
           <FieldCategoryBox
             :boxType="true"
             :value="FIELD_MAP[problem.field].value"
@@ -113,6 +113,12 @@ import { DIFFICULTY_MAP, FIELD_MAP } from "../../../../../../utils/constants"
 export default {
   name: "MostDifficultProblemLastWeekBox",
   components: { FieldCategoryBox },
+  props: {
+    showTags: {
+      type: Boolean,
+      default: true,
+    },
+  },
   data() {
     return {
       problem: null,

--- a/frontend/src/pages/oj/views/problem/problemList/rightSideComponent/PersonalRecommendationBox.vue
+++ b/frontend/src/pages/oj/views/problem/problemList/rightSideComponent/PersonalRecommendationBox.vue
@@ -35,6 +35,7 @@
           v-for="recommend_problem in recommendation.recommend_problems"
           :key="recommend_problem._id"
           :recommend_problem="recommend_problem"
+          :showTags="showTags"
         />
       </template>
     </template>
@@ -51,6 +52,12 @@ import InSufficientData from "./InSufficientData.vue"
 export default {
   name: "PersonalRecommendationBox",
   components: { InSufficientData, RecommendProblem },
+  props: {
+    showTags: {
+      type: Boolean,
+      default: true,
+    },
+  },
   data() {
     return {
       recommendation: null,

--- a/frontend/src/pages/oj/views/problem/problemList/rightSideComponent/RecommendProblem.vue
+++ b/frontend/src/pages/oj/views/problem/problemList/rightSideComponent/RecommendProblem.vue
@@ -12,7 +12,7 @@
           $t("m.Try_Personal_Recommendation_Problem")
         }}</span>
       </div>
-      <div class="problem-extra">
+      <div v-if="showTags" class="problem-extra">
         <FieldCategoryBox
           :boxType="true"
           :value="FIELD_MAP[recommend_problem.field].value"
@@ -44,6 +44,10 @@ export default defineComponent({
   },
   props: {
     recommend_problem: Object,
+    showTags: {
+      type: Boolean,
+      default: true,
+    },
   },
   components: {
     FieldCategoryBox,


### PR DESCRIPTION
# Changelog

- 문제 목록 태그 숨김 토글 추가
- 문제 목록 정렬 추가: 난이도, 맞힌 사람 수, 정답률
- 문제 목록 기본 표시 수 15개로 변경
- 표 내부 난이도 줄바꿈 방지

<img width="889" height="222" alt="image" src="https://github.com/user-attachments/assets/e7424711-a4aa-4f9e-bee8-0ee0ee81c1d9" />


# Testing

- `npm run lint` 통과
- `backend/manage.py test problem.tests.ProblemAPITest --keepdb` 통과
- 로컬에서 태그 숨김/정렬/15개 표시 확인

# Ops Impact

- DB 마이그레이션 없음
- 별도 운영 작업 없음

# Version Compatibility

- 기존 API 응답 스키마 변경 없음