### PR TITLE
backend/celery 단일 실행 구조로 고정

### DIFF
--- a/backend/deploy/entrypoint.sh
+++ b/backend/deploy/entrypoint.sh
@@ -19,8 +19,6 @@ if [ ! -f "$DATA/public/website/favicon.ico" ]; then
     cp data/public/website/favicon.ico $DATA/public/website
 fi
 
-: "${MAX_WORKER_NUM:=1}"
-
 cd /app
 
 n=0
@@ -51,8 +49,8 @@ exec gunicorn oj.wsgi \
     --user server \
     --group spj \
     --bind 0.0.0.0:8080 \
-    --workers "$MAX_WORKER_NUM" \
-    --threads 4 \
+    --workers 1 \
+    --threads 1 \
     --max-requests-jitter 10000 \
     --max-requests 1000000 \
     --keep-alive 32 \

--- a/backend/deploy/entrypoint_worker.sh
+++ b/backend/deploy/entrypoint_worker.sh
@@ -8,4 +8,4 @@ fi
 
 cd /app
 
-exec celery -A oj worker --loglevel=info --concurrency=1 --max-tasks-per-child=100
+exec celery -A oj worker --loglevel=info --pool=solo --concurrency=1


### PR DESCRIPTION
# Changelog

- Backend gunicorn을 `workers=1`, `threads=1`로 고정했습니다.
- Celery Worker를 `--pool=solo --concurrency=1`로 변경했습니다.
- Judge Server는 이번 PR 범위에서 제외했습니다.

# Testing

- `sh -n backend/deploy/entrypoint.sh`
- `sh -n backend/deploy/entrypoint_worker.sh`
- backend/celery 실행 옵션에서 단일 실행 설정 확인

# Ops Impact

- Backend/Celery Worker 재배포가 필요합니다.
- DB 마이그레이션은 없습니다.
- 처리량이 부족하면 내부 worker 수가 아니라 replica 수로 확장해야 합니다.

# Version Compatibility

- API/DB/클라이언트 호환성 영향 없습니다.
- `MAX_WORKER_NUM`은 더 이상 적용되지 않습니다.