### PR TITLE
#748 대회 문제 오답 시 질문하기 넛지 안 뜨도록 수정

### DIFF
--- a/frontend/src/pages/oj/views/problem/problemSolving/Problem.vue
+++ b/frontend/src/pages/oj/views/problem/problemSolving/Problem.vue
@@ -774,8 +774,8 @@ export default {
 
               this.leftPainActiveTab = "submission"
               this.lastSubmissionId = id
-              // 통과(Accepted=0)하지 못한 결과면 질문 유도 넛지 표시
-              this.showAskNudge = this.result.result !== 0
+              // 통과(Accepted=0)하지 못한 결과면 질문 유도 넛지 표시 (대회에서는 질문 기능 자체가 없으므로 제외)
+              this.showAskNudge = !this.isContestProblem && this.result.result !== 0
 
               clearTimeout(this.refreshStatus)
               this.init({


### PR DESCRIPTION


# Changelog
대회는 질문하기 탭/커뮤니티가 있어도 물어보면서 하는게 대회가 아니지만 오답 넛지가 떠서 이동 시 갈 곳이 없던 문제 수정. showAskNudge를 !isContestProblem 조건으로 제한.
<!-- 이 PR에서 변경된 내용을 자세하게 기술해주세요. -->
<!-- 추가/수정/삭제된 기능이나 버그 수정 사항을 명확히 작성해주세요. -->

# Testing

https://github.com/user-attachments/assets/f7c6a67c-51e7-4e15-a5a9-ed6e7fb4b78e



<!-- 테스트 방법과 결과를 상세히 기술해주세요. -->
<!-- 단위 테스트, 통합 테스트 결과나 수동 테스트 내용을 포함해주세요. -->
<!-- 스크린샷이나 로그도 첨부하면 좋습니다. -->

# Ops Impact
N/A
<!-- 이 변경사항이 운영에 미치는 영향을 설명해주세요. -->
<!-- 서버 재시작이 필요한지, DB 마이그레이션이 있는지, 성능에 영향을 주는지 등 운영팀이 알아야 할 사항을 기재해주세요. -->
<!-- 해당 사항이 없다면 N/A로 기재해주세요. -->

# Version Compatibility
N/A
<!-- 이 변경사항이 기존 버전과의 호환성에 영향을 주는지 설명해주세요. -->
<!-- 하위/상위 버전 호환성 이슈가 있는지, 클라이언트/서버 버전 동기화가 필요한지 등을 기재해주세요. -->
<!-- 해당 사항이 없다면 N/A로 기재해주세요. -->
