### PR TITLE
hotfix: dev Django 실행 환경 복원

### DIFF
--- a/kubernetes/overlays/dev/backend-deployment-patch.yaml
+++ b/kubernetes/overlays/dev/backend-deployment-patch.yaml
@@ -8,8 +8,6 @@ spec:
       containers:
         - name: backend
           env:
-            - name: OJ_ENV
-              value: "dev"
             - name: CSRF_TRUSTED_ORIGINS
               value: "https://k3s.code-place-dev.site"
             - name: SENTRY_DSN_BACKEND

--- a/kubernetes/overlays/dev/celery-beat-deployment-patch.yaml
+++ b/kubernetes/overlays/dev/celery-beat-deployment-patch.yaml
@@ -13,8 +13,6 @@ spec:
       containers:
         - name: celery-beat
           env:
-            - name: OJ_ENV
-              value: "dev"
             - name: SENTRY_DSN_BACKEND
               valueFrom:
                 secretKeyRef:

--- a/kubernetes/overlays/dev/celery-worker-deployment-patch.yaml
+++ b/kubernetes/overlays/dev/celery-worker-deployment-patch.yaml
@@ -16,8 +16,6 @@ spec:
       containers:
         - name: celery-worker
           env:
-            - name: OJ_ENV
-              value: "dev"
             - name: SENTRY_DSN_BACKEND
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
# Changelog

- dev Kubernetes에서 Django local 설정 전환을 제거해 `/data` PVC 경로 사용 복원

# Testing

- dev backend/celery/beat의 `OJ_ENV` 미지정 및 관측 환경 라벨 유지 확인

# Ops Impact

- dev overlay 재적용 시 backend/celery 재시작
- DB 마이그레이션 없음

# Version Compatibility

- N/A