### PR TITLE
#660 kube-vip 공통 Lease로 VIP 소유권 통합

### DIFF
--- a/kubernetes/setup/kube-vip/kube-vip.yaml.tpl
+++ b/kubernetes/setup/kube-vip/kube-vip.yaml.tpl
@@ -51,7 +51,7 @@ spec:
             - name: svc_enable
               value: "true"
             - name: svc_leasename
-              value: plndr-svcs-lock
+              value: plndr-cp-lock
             - name: vip_leaderelection
               value: "true"
             - name: vip_leasename


### PR DESCRIPTION
## 변경 사항

- Service와 control-plane이 동일한 `plndr-cp-lock` Lease를 사용하도록 변경했습니다.

## 변경 이유

동일한 VIP를 서로 다른 리더가 광고하면서 발생할 수 있는 ARP 및 연결 불안정을 방지합니다.

## 검증

- YAML 파싱 확인
- 두 Lease 설정 일치 확인