### PR TITLE
fix: kube-vip 공통 Lease 충돌 해소

### DIFF
--- a/kubernetes/setup/kube-vip/kube-vip.yaml.tpl
+++ b/kubernetes/setup/kube-vip/kube-vip.yaml.tpl
@@ -3,7 +3,7 @@ kind: DaemonSet
 metadata:
   labels:
     app.kubernetes.io/name: kube-vip-ds
-    app.kubernetes.io/version: v1.0.2
+    app.kubernetes.io/version: v1.2.2
   name: kube-vip-ds
   namespace: kube-system
 spec:
@@ -14,7 +14,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: kube-vip-ds
-        app.kubernetes.io/version: v1.0.2
+        app.kubernetes.io/version: v1.2.2
     spec:
       affinity:
         nodeAffinity:
@@ -66,7 +66,7 @@ spec:
               value: ##VIP_ADDRESS##
             - name: prometheus_server
               value: :2112
-          image: ghcr.io/kube-vip/kube-vip:v1.0.2
+          image: ghcr.io/kube-vip/kube-vip:v1.2.2
           imagePullPolicy: IfNotPresent
           name: kube-vip
           resources: {}


### PR DESCRIPTION
## 변경 사항
- kube-vip을 v1.0.2에서 v1.2.2로 업데이트했습니다.

## 변경 이유
공통 Lease 사용 시 구버전의 Control Plane과 Service election이 동일 Lease를 중복 갱신하며 발생하는 충돌을 해결합니다.

## 검증
- YAML 파싱 확인
- 공통 Lease 및 이미지 버전 확인